### PR TITLE
Convenience peripheral functions implementation.

### DIFF
--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		26509A771CC1270100EBA319 /* DeviceIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26509A761CC1270100EBA319 /* DeviceIdentifiers.swift */; };
+		26509A791CC1275E00EBA319 /* Peripheral+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26509A781CC1275E00EBA319 /* Peripheral+Convenience.swift */; };
 		A1299BC11CBE3D52005DEA5B /* RxBluetoothKit.h in Headers */ = {isa = PBXBuildFile; fileRef = A1299BC01CBE3D52005DEA5B /* RxBluetoothKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A1299BC81CBE3D52005DEA5B /* RxBluetoothKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1299BBD1CBE3D52005DEA5B /* RxBluetoothKit.framework */; };
 		A1299C251CBE3DEE005DEA5B /* AdvertisementData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0C1CBE3DEE005DEA5B /* AdvertisementData.swift */; };
@@ -84,6 +86,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		26509A761CC1270100EBA319 /* DeviceIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceIdentifiers.swift; sourceTree = "<group>"; };
+		26509A781CC1275E00EBA319 /* Peripheral+Convenience.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Peripheral+Convenience.swift"; sourceTree = "<group>"; };
 		A1299BBD1CBE3D52005DEA5B /* RxBluetoothKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBluetoothKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1299BC01CBE3D52005DEA5B /* RxBluetoothKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RxBluetoothKit.h; sourceTree = "<group>"; };
 		A1299BC21CBE3D52005DEA5B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -210,6 +214,8 @@
 				A1299C211CBE3DEE005DEA5B /* ScannedPeripheral.swift */,
 				A1299C161CBE3DEE005DEA5B /* Peripheral.swift */,
 				A1299C1A1CBE3DEE005DEA5B /* RxCBPeripheral.swift */,
+				26509A761CC1270100EBA319 /* DeviceIdentifiers.swift */,
+				26509A781CC1275E00EBA319 /* Peripheral+Convenience.swift */,
 			);
 			name = Peripheral;
 			sourceTree = "<group>";
@@ -454,6 +460,7 @@
 				A1299C2B1CBE3DEE005DEA5B /* Descriptor.swift in Sources */,
 				A1299C331CBE3DEE005DEA5B /* RxCBPeripheral.swift in Sources */,
 				A1299C2A1CBE3DEE005DEA5B /* CollectionUtils.swift in Sources */,
+				26509A791CC1275E00EBA319 /* Peripheral+Convenience.swift in Sources */,
 				A1299C3B1CBE3DEE005DEA5B /* ScanOperation.swift in Sources */,
 				A1299C311CBE3DEE005DEA5B /* RxCBCharacteristic.swift in Sources */,
 				A1299C2C1CBE3DEE005DEA5B /* Observable+Absorb.swift in Sources */,
@@ -468,6 +475,7 @@
 				A1299C291CBE3DEE005DEA5B /* Characteristic.swift in Sources */,
 				A1299C3C1CBE3DEE005DEA5B /* Service.swift in Sources */,
 				A1299C341CBE3DEE005DEA5B /* RxCBService.swift in Sources */,
+				26509A771CC1270100EBA319 /* DeviceIdentifiers.swift in Sources */,
 				A1299C261CBE3DEE005DEA5B /* BluetoothError.swift in Sources */,
 				A1299C371CBE3DEE005DEA5B /* RxDescriptorType.swift in Sources */,
 				A1299C351CBE3DEE005DEA5B /* RxCentralManagerType.swift in Sources */,

--- a/RxBluetoothKit/Characteristic.swift
+++ b/RxBluetoothKit/Characteristic.swift
@@ -39,7 +39,7 @@ public class Characteristic {
     }
 
     /// Characteristic UUID
-    public var uuid: CBUUID {
+    public var UUID: CBUUID {
         return characteristic.uuid
     }
 
@@ -76,6 +76,10 @@ public class Characteristic {
      */
     public func monitorWrite() -> Observable<Characteristic> {
         return service.peripheral.monitorWriteForCharacteristic(self)
+    }
+    //TODO: Add documentation
+    public func discoverDescriptors(identifiers: [CBUUID]) -> Observable<[Descriptor]> {
+        return self.service.peripheral.discoverDescriptorsForCharacteristic(self)
     }
 
     /**

--- a/RxBluetoothKit/DeviceIdentifiers.swift
+++ b/RxBluetoothKit/DeviceIdentifiers.swift
@@ -35,3 +35,4 @@ protocol CharacteristicIdentifier {
     var UUID: CBUUID { get }
     var service: ServiceIdentifier { get }
 }
+

--- a/RxBluetoothKit/DeviceIdentifiers.swift
+++ b/RxBluetoothKit/DeviceIdentifiers.swift
@@ -1,0 +1,37 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import CoreBluetooth
+
+protocol ServiceIdentifier {
+    var UUID: CBUUID { get }
+}
+
+protocol DescriptorIdentifier {
+    var UUID: CBUUID { get }
+    var characteristic: CharacteristicIdentifier { get }
+}
+
+protocol CharacteristicIdentifier {
+    var UUID: CBUUID { get }
+    var service: ServiceIdentifier { get }
+}

--- a/RxBluetoothKit/Peripheral+Convenience.swift
+++ b/RxBluetoothKit/Peripheral+Convenience.swift
@@ -1,0 +1,138 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import CoreBluetooth
+import RxSwift
+
+extension Peripheral {
+
+    private func getService(id: ServiceIdentifier) -> Observable<Service> {
+        return Observable.deferred {
+            if let services = self.services,
+                let service = services.findElement({ $0.UUID == id.UUID  }) {
+                return Observable.just(service)
+            } else {
+                return Observable.from(self.discoverServices([id.UUID]))
+            }
+        }
+    }
+
+    func getCharacteristic(id: CharacteristicIdentifier) -> Observable<Characteristic> {
+        return Observable.deferred {
+            return self.getService(id.service)
+                .flatMap { service -> Observable<Characteristic> in
+                    if let characteristics = service.characteristics, let characteristic = characteristics.findElement({
+                        $0.UUID == id.UUID
+                    }) {
+                        return Observable.just(characteristic)
+                    } else {
+                        return Observable.from(service.discoverCharacteristics([id.UUID]))
+                    }
+            }
+        }
+    }
+
+    func getDescriptor(id: DescriptorIdentifier) -> Observable<Descriptor> {
+        return Observable.deferred {
+            return self.getCharacteristic(id.characteristic)
+                .flatMap { characteristic -> Observable<Descriptor> in
+                    if let descriptors = characteristic.descriptors,
+                        let descriptor = descriptors.findElement({ $0.UUID == id.UUID }) {
+                        return Observable.just(descriptor)
+                    } else {
+                        return Observable.from(characteristic.discoverDescriptors([id.UUID]))
+                    }
+            }
+        }
+    }
+
+    func monitorWriteForCharacteristicWithId(id: CharacteristicIdentifier) -> Observable<Characteristic> {
+        return getCharacteristic(id)
+            .flatMap {
+                return self.monitorWriteForCharacteristic($0)
+        }
+    }
+
+    func writeValue(data: NSData, forCharacteristicWithId id: CharacteristicIdentifier, type: CBCharacteristicWriteType)
+        -> Observable<Characteristic> {
+        return getCharacteristic(id)
+            .flatMap {
+                return self.writeValue(data, forCharacteristic: $0, type: type)
+        }
+    }
+
+    func monitorValueUpdateForCharacteristicWithId(id: CharacteristicIdentifier) -> Observable<Characteristic> {
+        return getCharacteristic(id)
+            .flatMap {
+                return self.monitorValueUpdateForCharacteristic($0)
+        }
+    }
+
+    func readValueForCharacteristicWithId(id: CharacteristicIdentifier) -> Observable<Characteristic> {
+        return getCharacteristic(id)
+            .flatMap {
+                return self.readValueForCharacteristic($0)
+        }
+    }
+
+    func discoverDescriptorsForCharacteristicWithId(id: CharacteristicIdentifier) -> Observable<[Descriptor]> {
+        return getCharacteristic(id)
+            .flatMap {
+                return self.discoverDescriptorsForCharacteristic($0)
+        }
+    }
+
+    func monitorWriteForDescriptorWithId(id: DescriptorIdentifier) -> Observable<Descriptor> {
+        return getDescriptor(id)
+            .flatMap {
+                return self.monitorWriteForDescriptor($0)
+        }
+    }
+
+    func writeValue(data: NSData, forDescriptorWithId id: DescriptorIdentifier) -> Observable<Descriptor> {
+        return getDescriptor(id)
+            .flatMap {
+                return self.writeValue(data, forDescriptor: $0)
+        }
+    }
+
+    func monitorValueUpdateForDescriptorWithId(id: DescriptorIdentifier) -> Observable<Descriptor> {
+        return getDescriptor(id)
+            .flatMap {
+                return self.monitorValueUpdateForDescriptor($0)
+        }
+    }
+    func readValueForDescriptorWithId(id: DescriptorIdentifier) -> Observable<Descriptor> {
+        return getDescriptor(id)
+            .flatMap {
+                return self.readValueForDescriptor($0)
+        }
+    }
+    func setNotifyValue(enabled: Bool,
+                        forCharacteristicWithId id: CharacteristicIdentifier) -> Observable<Characteristic> {
+        return getCharacteristic(id)
+            .flatMap {
+                return self.setNotifyValue(enabled, forCharacteristic: $0)
+        }
+    }
+}

--- a/RxBluetoothKit/Peripheral+Convenience.swift
+++ b/RxBluetoothKit/Peripheral+Convenience.swift
@@ -26,111 +26,115 @@ import RxSwift
 
 extension Peripheral {
 
-    private func getService(id: ServiceIdentifier) -> Observable<Service> {
+    private func serviceWithIdentifier(identifier: ServiceIdentifier) -> Observable<Service> {
         return Observable.deferred {
             if let services = self.services,
-                let service = services.findElement({ $0.UUID == id.UUID  }) {
+                let service = services.findElement({ $0.UUID == identifier.UUID  }) {
                 return Observable.just(service)
             } else {
-                return Observable.from(self.discoverServices([id.UUID]))
+                return Observable.from(self.discoverServices([identifier.UUID]))
             }
         }
     }
 
-    func getCharacteristic(id: CharacteristicIdentifier) -> Observable<Characteristic> {
+    func characteristicWithIdentifier(identifier: CharacteristicIdentifier) -> Observable<Characteristic> {
         return Observable.deferred {
-            return self.getService(id.service)
+            return self.serviceWithIdentifier(identifier.service)
                 .flatMap { service -> Observable<Characteristic> in
                     if let characteristics = service.characteristics, let characteristic = characteristics.findElement({
-                        $0.UUID == id.UUID
+                        $0.UUID == identifier.UUID
                     }) {
                         return Observable.just(characteristic)
                     } else {
-                        return Observable.from(service.discoverCharacteristics([id.UUID]))
+                        return Observable.from(service.discoverCharacteristics([identifier.UUID]))
                     }
             }
         }
     }
 
-    func getDescriptor(id: DescriptorIdentifier) -> Observable<Descriptor> {
+    func descriptorWithIdentifier(identifier: DescriptorIdentifier) -> Observable<Descriptor> {
         return Observable.deferred {
-            return self.getCharacteristic(id.characteristic)
+            return self.characteristicWithIdentifier(identifier.characteristic)
                 .flatMap { characteristic -> Observable<Descriptor> in
                     if let descriptors = characteristic.descriptors,
-                        let descriptor = descriptors.findElement({ $0.UUID == id.UUID }) {
+                        let descriptor = descriptors.findElement({ $0.UUID == identifier.UUID }) {
                         return Observable.just(descriptor)
                     } else {
-                        return Observable.from(characteristic.discoverDescriptors([id.UUID]))
+                        return Observable.from(characteristic.discoverDescriptors([identifier.UUID]))
                     }
             }
         }
     }
 
-    func monitorWriteForCharacteristicWithId(id: CharacteristicIdentifier) -> Observable<Characteristic> {
-        return getCharacteristic(id)
+    func monitorWriteForCharacteristicWithIdentifier(identifier: CharacteristicIdentifier)
+        -> Observable<Characteristic> {
+        return characteristicWithIdentifier(identifier)
             .flatMap {
                 return self.monitorWriteForCharacteristic($0)
         }
     }
 
-    func writeValue(data: NSData, forCharacteristicWithId id: CharacteristicIdentifier, type: CBCharacteristicWriteType)
-        -> Observable<Characteristic> {
-        return getCharacteristic(id)
+    func writeValue(data: NSData, forCharacteristicWithIdentifier identifier: CharacteristicIdentifier,
+                    type: CBCharacteristicWriteType) -> Observable<Characteristic> {
+        return characteristicWithIdentifier(identifier)
             .flatMap {
                 return self.writeValue(data, forCharacteristic: $0, type: type)
         }
     }
 
-    func monitorValueUpdateForCharacteristicWithId(id: CharacteristicIdentifier) -> Observable<Characteristic> {
-        return getCharacteristic(id)
+    func monitorValueUpdateForCharacteristicWithIdentifier(identifier: CharacteristicIdentifier)
+        -> Observable<Characteristic> {
+        return characteristicWithIdentifier(identifier)
             .flatMap {
                 return self.monitorValueUpdateForCharacteristic($0)
         }
     }
 
-    func readValueForCharacteristicWithId(id: CharacteristicIdentifier) -> Observable<Characteristic> {
-        return getCharacteristic(id)
+    func readValueForCharacteristicWithIdentifier(identifier: CharacteristicIdentifier) -> Observable<Characteristic> {
+        return characteristicWithIdentifier(identifier)
             .flatMap {
                 return self.readValueForCharacteristic($0)
         }
     }
 
-    func discoverDescriptorsForCharacteristicWithId(id: CharacteristicIdentifier) -> Observable<[Descriptor]> {
-        return getCharacteristic(id)
+    func discoverDescriptorsForCharacteristicWithIdentifier(identifier: CharacteristicIdentifier) ->
+        Observable<[Descriptor]> {
+        return characteristicWithIdentifier(identifier)
             .flatMap {
                 return self.discoverDescriptorsForCharacteristic($0)
         }
     }
 
-    func monitorWriteForDescriptorWithId(id: DescriptorIdentifier) -> Observable<Descriptor> {
-        return getDescriptor(id)
+    func monitorWriteForDescriptorWithIdentifier(identifier: DescriptorIdentifier) -> Observable<Descriptor> {
+        return descriptorWithIdentifier(identifier)
             .flatMap {
                 return self.monitorWriteForDescriptor($0)
         }
     }
 
-    func writeValue(data: NSData, forDescriptorWithId id: DescriptorIdentifier) -> Observable<Descriptor> {
-        return getDescriptor(id)
+    func writeValue(data: NSData, forDescriptorWithIdentifier identifier: DescriptorIdentifier)
+        -> Observable<Descriptor> {
+        return descriptorWithIdentifier(identifier)
             .flatMap {
                 return self.writeValue(data, forDescriptor: $0)
         }
     }
 
-    func monitorValueUpdateForDescriptorWithId(id: DescriptorIdentifier) -> Observable<Descriptor> {
-        return getDescriptor(id)
+    func monitorValueUpdateForDescriptorWithIdentifier(identifier: DescriptorIdentifier) -> Observable<Descriptor> {
+        return descriptorWithIdentifier(identifier)
             .flatMap {
                 return self.monitorValueUpdateForDescriptor($0)
         }
     }
-    func readValueForDescriptorWithId(id: DescriptorIdentifier) -> Observable<Descriptor> {
-        return getDescriptor(id)
+    func readValueForDescriptorWithIdentifier(identifier: DescriptorIdentifier) -> Observable<Descriptor> {
+        return descriptorWithIdentifier(identifier)
             .flatMap {
                 return self.readValueForDescriptor($0)
         }
     }
-    func setNotifyValue(enabled: Bool,
-                        forCharacteristicWithId id: CharacteristicIdentifier) -> Observable<Characteristic> {
-        return getCharacteristic(id)
+    func setNotifyValue(enabled: Bool, forCharacteristicWithIdentifier identifier: CharacteristicIdentifier)
+        -> Observable<Characteristic> {
+        return characteristicWithIdentifier(identifier)
             .flatMap {
                 return self.setNotifyValue(enabled, forCharacteristic: $0)
         }

--- a/RxBluetoothKit/Peripheral.swift
+++ b/RxBluetoothKit/Peripheral.swift
@@ -129,7 +129,7 @@ public class Peripheral {
                 let mapped = includedServices.map { Service(peripheral: self, service: $0) }
                 guard includedServiceUUIDs != nil else { return Observable.just(mapped) }
                 return Observable.just(mapped
-                .filter { self.shouldBeIdentifierIncluded($0.uuid, forIdentifiers: includedServiceUUIDs) })
+                .filter { self.shouldBeIdentifierIncluded($0.UUID, forIdentifiers: includedServiceUUIDs) })
             }
             .take(1)
 
@@ -158,7 +158,7 @@ public class Peripheral {
             let mapped = characteristics.map { Characteristic(characteristic: $0, service: service) }
             guard identifiers != nil else { return Observable.just(mapped) }
             return Observable.just(mapped
-                .filter { self.shouldBeIdentifierIncluded($0.uuid, forIdentifiers: identifiers) })
+                .filter { self.shouldBeIdentifierIncluded($0.UUID, forIdentifiers: identifiers) })
         }
         .take(1)
 

--- a/RxBluetoothKit/Service.swift
+++ b/RxBluetoothKit/Service.swift
@@ -39,7 +39,7 @@ public class Service {
     }
 
     /// Service's UUID
-    public var uuid: CBUUID {
+    public var UUID: CBUUID {
         return service.uuid
     }
 


### PR DESCRIPTION
I've written convenience functions to `Peripheral` as an extension.
Motivation is to provide to user simpler interface and not force him to use every time `discover` methods.
With this, user can create for example enums for every device he wants to use like that:
```
enum XXXCharacteristic: String, CharacteristicIdentifier {
    case ManufacturerName = "2A29"
    case GenericCommunication = "XXXX"

    var UUID: CBUUID {
        return CBUUID(string: self.rawValue)
    }
    var service: ServiceIdentifier {
        switch self {
        case .ManufacturerName:
            return XXXService.DeviceInformation
        case .GenericCommunication:
            return XXXService.GenericCommunication
        }
    }
}
enum XXXService: String, ServiceIdentifier {
    case DeviceInformation = "180A"
    case GenericCommunication = "XXX"

    var UUID: CBUUID {
        return CBUUID(string: self.rawValue)
    }
}
```
Later, thanks to that, simple action like making connection and reading value shortens from:
```
peripheral.connect()
    .flatMap { Observable.from($0.discoverServices([serviceId])) }
    .flatMap { Observable.from($0.discoverCharacteristics([characteristicId])}
    .flatMap { $0.readValue }
    .subscribeNext {
        let data = $0.value
    }
```
to:
```
peripheral.connect()
    .flatMap { $0.readValueFromCharacteristicWithId(XXXCharacteristic.ManufacturerName)
    .subscribeNext {
        let data = $0.value
    }
```
Also, if characteristic / descriptor / service is available in cache - we use it.