### PR TITLE
Semantic change to `setNotificationAndMonitorChanges` and README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ characteristic.setNotificationAndMonitorUpdates()
 		let newValue = $0.value
 	}
 ```
-If you are not interested anymore in updates, just use this:
+If you are not interested anymore in updates, just use dispose this subscription - it will automatically set notification state on `false`.
+When you want to set notification state without monitoring updates, you should subscribe to: `characteristic.setNotifyValue(true)` method. Similarly: if you want to manually set notification state on `false` : subscribe to `characteristic.setNotifyValue(false)`
+
 ```swift
 characteristic.setNotifyValue(false)
 	.subscribe { characteristic in

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -327,9 +327,15 @@ public class Peripheral {
      */
     public func setNotificationAndMonitorUpdatesForCharacteristic(characteristic: Characteristic)
         -> Observable<Characteristic> {
-            return Observable.of(monitorValueUpdateForCharacteristic(characteristic),
-            setNotifyValue(true, forCharacteristic: characteristic).ignoreElements()
-                .subscribeOn(CurrentThreadScheduler.instance)).merge()
+        return Observable.create { observer in
+            let disposable = Observable.of(self.monitorValueUpdateForCharacteristic(characteristic),
+                self.setNotifyValue(true, forCharacteristic: characteristic).ignoreElements()
+                    .subscribeOn(CurrentThreadScheduler.instance)).merge().subscribe(observer)
+            return AnonymousDisposable {
+                disposable.dispose()
+                self.peripheral.setNotifyValue(false, forCharacteristic: characteristic.characteristic)
+            }
+        }
     }
 
     //MARK: Descriptors


### PR DESCRIPTION

Changes we've been talking about - we've decided to disable notifications on dispose in `setNotificationAndMonitor` method. I'm not entirely sure about explaining this in README in current form - we could discuss it.

Thanks!