### PR TITLE
Fix stuck service discovery when looking for different services

### DIFF
--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -134,7 +134,7 @@ public class Peripheral {
 					let mapped = discoveredServices.map { Service(peripheral: self, service: $0) }
 					guard let identifiers = serviceUUIDs else { return Observable.just(mapped) }
 					let uuids = discoveredServices.map { $0.uuid }
-					if Set(uuids) == Set(identifiers) {
+					if Set(identifiers).isSubsetOf(Set(uuids)) {
 						return Observable.just(mapped)
 					}
 					return Observable.empty()


### PR DESCRIPTION
Subsequent calls to discoverServices method in Peripheral with different services UUIDs causing it to return an empty sequence instead of success. This happens because after the first call the peripheral already has some discovered services and in the next call the comparison between sets of services identifiers fails if you ask to discover another service