### PR TITLE
Remove iOS platform specification from podspec

### DIFF
--- a/RxBluetoothKit.podspec
+++ b/RxBluetoothKit.podspec
@@ -16,7 +16,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
 
-  s.platform     = :ios, '8.0'
   s.requires_arc = true
 
   s.source_files = 'Source/*.swift'


### PR DESCRIPTION
The podspec currently includes a `platform` definition for iOS in addition to the `deployment_target` definitions. This means when trying to install RxBluetoothKit in a Mac app, it fails with:

```
[!] The platform of the target `RxBluetoothKitTest` (OS X 10.10) is not compatible with `RxBluetoothKit (1.2.3)`, which does not support `osx`.
```

Because `deployment_target`s are defined, the `platform` definition can be removed, [as it shouldn't be used for multiple platforms](https://guides.cocoapods.org/syntax/podspec.html#platform).

Thanks for making a super cool library!