### PR TITLE
Fixed RxTest.framework reference and minor changes

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,13 +4,13 @@ disabled_rules: # rule identifiers to exclude from running
   - todo #delete it later
 opt_in_rules: # some rules are only opt-in
   - empty_count
-  - missing_docs
+  # - missing_docs # Broken in swiftlint 0.12.0 with XCode 8
   # Find all the available rules by running:
   # swiftlint rules
 excluded:
   - Carthage
   - Example
-  - RxBluetoothKitTests
+  - Tests
 
   
 line_length: 120

--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A20F0101DB4C01D00A1A805 /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A20F00F1DB4C01C00A1A805 /* RxTest.framework */; };
+		0A20F0121DB4C02B00A1A805 /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A20F0111DB4C02B00A1A805 /* RxTest.framework */; };
 		2666FD8E1CCE457C005E81CE /* RxBluetoothKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FD841CCE457C005E81CE /* RxBluetoothKit.framework */; };
 		2666FD9D1CCE45E3005E81CE /* RxBluetoothKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 2666FCEE1CCE42A5005E81CE /* RxBluetoothKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2666FDAD1CCE4626005E81CE /* RxBluetoothKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FDA31CCE4626005E81CE /* RxBluetoothKit.framework */; };
@@ -88,11 +90,9 @@
 		A10F298A1CDCD6E100593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5A1CCE65CD005E81CE /* RxSwift.framework */; };
 		A10F298B1CDCD6E400593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5E1CCE65EE005E81CE /* RxSwift.framework */; };
 		A10F29A11CDCD74B00593284 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10F29921CDCD72200593284 /* Nimble.framework */; };
-		A10F29A21CDCD74F00593284 /* RxTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10F29901CDCD72200593284 /* RxTests.framework */; };
 		A10F29A31CDCD75200593284 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10F29911CDCD72200593284 /* Quick.framework */; };
 		A10F29A41CDCD75600593284 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10F299A1CDCD73A00593284 /* Nimble.framework */; };
 		A10F29A51CDCD75900593284 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10F29991CDCD73A00593284 /* Quick.framework */; };
-		A10F29A61CDCD75C00593284 /* RxTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10F29981CDCD73A00593284 /* RxTests.framework */; };
 		A10F29AD1CDCD98400593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5A1CCE65CD005E81CE /* RxSwift.framework */; };
 		A10F29B01CDCD99900593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5E1CCE65EE005E81CE /* RxSwift.framework */; };
 /* End PBXBuildFile section */
@@ -137,6 +137,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0A20F00F1DB4C01C00A1A805 /* RxTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTest.framework; path = Carthage/Build/Mac/RxTest.framework; sourceTree = SOURCE_ROOT; };
+		0A20F0111DB4C02B00A1A805 /* RxTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTest.framework; path = Carthage/Build/iOS/RxTest.framework; sourceTree = SOURCE_ROOT; };
 		26509A761CC1270100EBA319 /* DeviceIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceIdentifiers.swift; sourceTree = "<group>"; };
 		26509A781CC1275E00EBA319 /* Peripheral+Convenience.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Peripheral+Convenience.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		2666FCED1CCE42A5005E81CE /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Source/Info.plist; sourceTree = "<group>"; };
@@ -161,10 +163,8 @@
 		2666FE5E1CCE65EE005E81CE /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/Mac/RxSwift.framework; sourceTree = SOURCE_ROOT; };
 		26EF38C81D86EE1F00F9F468 /* BluetoothState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BluetoothState.swift; sourceTree = "<group>"; };
 		26F3034A1CF0D49D00D74EBF /* RestoredState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestoredState.swift; sourceTree = "<group>"; };
-		A10F29901CDCD72200593284 /* RxTests.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTests.framework; path = Carthage/Build/Mac/RxTests.framework; sourceTree = SOURCE_ROOT; };
 		A10F29911CDCD72200593284 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = SOURCE_ROOT; };
 		A10F29921CDCD72200593284 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = SOURCE_ROOT; };
-		A10F29981CDCD73A00593284 /* RxTests.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTests.framework; path = Carthage/Build/iOS/RxTests.framework; sourceTree = SOURCE_ROOT; };
 		A10F29991CDCD73A00593284 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = SOURCE_ROOT; };
 		A10F299A1CDCD73A00593284 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		A1299C0C1CBE3DEE005DEA5B /* AdvertisementData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdvertisementData.swift; sourceTree = "<group>"; };
@@ -197,7 +197,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A20F0101DB4C01D00A1A805 /* RxTest.framework in Frameworks */,
 				A10F298A1CDCD6E100593284 /* RxSwift.framework in Frameworks */,
+				0A20F0121DB4C02B00A1A805 /* RxTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -208,7 +210,6 @@
 				A10F29AD1CDCD98400593284 /* RxSwift.framework in Frameworks */,
 				2666FD8E1CCE457C005E81CE /* RxBluetoothKit.framework in Frameworks */,
 				A10F29A41CDCD75600593284 /* Nimble.framework in Frameworks */,
-				A10F29A61CDCD75C00593284 /* RxTests.framework in Frameworks */,
 				A10F29A51CDCD75900593284 /* Quick.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -228,7 +229,6 @@
 				A10F29A31CDCD75200593284 /* Quick.framework in Frameworks */,
 				2666FDAD1CCE4626005E81CE /* RxBluetoothKit.framework in Frameworks */,
 				A10F29B01CDCD99900593284 /* RxSwift.framework in Frameworks */,
-				A10F29A21CDCD74F00593284 /* RxTests.framework in Frameworks */,
 				A10F29A11CDCD74B00593284 /* Nimble.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -386,7 +386,7 @@
 		A10F298C1CDCD6EB00593284 /* OSX */ = {
 			isa = PBXGroup;
 			children = (
-				A10F29901CDCD72200593284 /* RxTests.framework */,
+				0A20F00F1DB4C01C00A1A805 /* RxTest.framework */,
 				A10F29911CDCD72200593284 /* Quick.framework */,
 				A10F29921CDCD72200593284 /* Nimble.framework */,
 			);
@@ -396,7 +396,7 @@
 		A10F298D1CDCD6F200593284 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				A10F29981CDCD73A00593284 /* RxTests.framework */,
+				0A20F0111DB4C02B00A1A805 /* RxTest.framework */,
 				A10F29991CDCD73A00593284 /* Quick.framework */,
 				A10F299A1CDCD73A00593284 /* Nimble.framework */,
 			);

--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0A20F0101DB4C01D00A1A805 /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A20F00F1DB4C01C00A1A805 /* RxTest.framework */; };
-		0A20F0121DB4C02B00A1A805 /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A20F0111DB4C02B00A1A805 /* RxTest.framework */; };
 		2666FD8E1CCE457C005E81CE /* RxBluetoothKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FD841CCE457C005E81CE /* RxBluetoothKit.framework */; };
 		2666FD9D1CCE45E3005E81CE /* RxBluetoothKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 2666FCEE1CCE42A5005E81CE /* RxBluetoothKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2666FDAD1CCE4626005E81CE /* RxBluetoothKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FDA31CCE4626005E81CE /* RxBluetoothKit.framework */; };
@@ -197,9 +195,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0A20F0101DB4C01D00A1A805 /* RxTest.framework in Frameworks */,
 				A10F298A1CDCD6E100593284 /* RxSwift.framework in Frameworks */,
-				0A20F0121DB4C02B00A1A805 /* RxTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -164,7 +164,7 @@ public class BluetoothManager {
 
                         // Start scanning for devices
                         self.centralManager.scanForPeripherals(withServices: serviceUUIDs, options: options)
-                        
+
                         return Disposables.create {
                             // When disposed, stop all scans, and remove scanning operation from queue
                             self.centralManager.stopScan()
@@ -210,7 +210,7 @@ public class BluetoothManager {
 
      - returns: Current state of `BluetoothManager` as `BluetoothState`.
      */
-    
+
     public var state: BluetoothState {
         return centralManager.state
     }
@@ -255,11 +255,11 @@ public class BluetoothManager {
                     observer.onCompleted()
                     return Disposables.create()
                 }
-                
+
                 let disposable = success.amb(error).subscribe(observer)
-                
+
                 self.centralManager.connect(peripheral.peripheral, options: options)
-                
+
                 return Disposables.create {
                     if !peripheral.isConnected {
                         self.centralManager.cancelPeripheralConnection(peripheral.peripheral)
@@ -329,7 +329,7 @@ public class BluetoothManager {
     }
 
     // MARK:  Internal functions
-    
+
     /**
      Ensure that `state` is and will be the only state of `BluetoothManager` during subscription.
      Otherwise error is emitted.

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -508,17 +508,21 @@ public class Peripheral {
 
     /**
      Function that allow user to monitor incoming `name` property changes of `Peripheral` instance.
-     - returns: Observable that emits tuples: `(Peripheral, String?)` when name has changed. It's `optional String` because peripheral could also lost his name. It's **infinite** stream of values, so `.Complete` is never emitted.
+     - returns: Observable that emits tuples: `(Peripheral, String?)` when name has changed.
+        It's `optional String` because peripheral could also lost his name.
+        It's **infinite** stream of values, so `.Complete` is never emitted.
      */
     public func monitorNameUpdate() -> Observable<(Peripheral, String?)> {
         return peripheral.rx_didUpdateName.map { return (self, $0) }
     }
 
     /**
-     Function that allow to monitor incoming service modifications for `Peripheral` instance. In case you're interested what exact changes might occur - please refer to
+     Function that allow to monitor incoming service modifications for `Peripheral` instance.
+     In case you're interested what exact changes might occur - please refer to
      [Apple Documentation](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBPeripheralDelegate_Protocol/#//apple_ref/occ/intfm/CBPeripheralDelegate/peripheral:didModifyServices:)
 
-     - returns: Observable that emits tuples: `(Peripheral, [Service])` when services were modified. It's **infinite** stream of values, so `.Complete` is never emitted.
+     - returns: Observable that emits tuples: `(Peripheral, [Service])` when services were modified.
+        It's **infinite** stream of values, so `.Complete` is never emitted.
      */
     public func monitorServicesModification() -> Observable<(Peripheral, [Service])> {
         let observable = peripheral.rx_didModifyServices

--- a/Source/RestoredState.swift
+++ b/Source/RestoredState.swift
@@ -46,7 +46,9 @@ public struct RestoredState {
     }
 
     /**
-     Array of `Peripheral` objects which have been restored. These are peripherals that were connected to the central manager (or had a connection pending) at the time the app was terminated by the system.
+     Array of `Peripheral` objects which have been restored.
+     These are peripherals that were connected to the central manager (or had a connection pending)
+     at the time the app was terminated by the system.
      */
     public var peripherals: [Peripheral] {
         let objects = restoredStateData[CBCentralManagerRestoredStatePeripheralsKey] as? [AnyObject]
@@ -57,14 +59,16 @@ public struct RestoredState {
     }
 
     /**
-     Dictionary that contains all of the peripheral scan options that were being used by the central manager at the time the app was terminated by the system.
+     Dictionary that contains all of the peripheral scan options that were being used
+     by the central manager at the time the app was terminated by the system.
     */
     public var scanOptions: [String : AnyObject]? {
         return restoredStateData[CBCentralManagerRestoredStatePeripheralsKey] as? [String : AnyObject]
     }
 
     /**
-     Array of `Service` objects which have been restored. These are all the services the central manager was scanning for at the time the app was terminated by the system.
+     Array of `Service` objects which have been restored.
+     These are all the services the central manager was scanning for at the time the app was terminated by the system.
      */
     public var services: [Service] {
         let objects = restoredStateData[CBCentralManagerRestoredStateScanServicesKey] as? [AnyObject]

--- a/Source/RxCBCentralManager.swift
+++ b/Source/RxCBCentralManager.swift
@@ -56,11 +56,11 @@ class RxCBCentralManager: RxCentralManagerType {
             didUpdateStateSubject.onNext(bleState)
         }
 
-        
+
         @objc func centralManager(_ central: CBCentralManager, willRestoreState dict: [String : Any]) {
             willRestoreStateSubject.onNext(dict)
         }
-        
+
         @objc func centralManager(_ central: CBCentralManager,
             didDiscover peripheral: CBPeripheral,
             advertisementData: [String: Any],
@@ -165,7 +165,7 @@ class RxCBCentralManager: RxCentralManagerType {
             RxCBPeripheral(peripheral: $0)
         })
     }
-    
+
     /**
      Retrieve peripherals with specified identifiers.
 

--- a/Source/RxCentralManagerType.swift
+++ b/Source/RxCentralManagerType.swift
@@ -44,7 +44,7 @@ protocol RxCentralManagerType {
 
     /// Current state of Central Manager
     var state: BluetoothState { get }
-    
+
     /**
      Start scanning for peripherals with specified services. Results will be available on rx_didDiscoverPeripheral
      observable.

--- a/Source/RxCharacteristicType.swift
+++ b/Source/RxCharacteristicType.swift
@@ -70,11 +70,6 @@ func == (lhs: [RxCharacteristicType], rhs: [RxCharacteristicType]) -> Bool {
     guard lhs.count == rhs.count else {
         return false
     }
-    var i1 = lhs.makeIterator()
-    var i2 = rhs.makeIterator()
-    var isEqual = true
-    while let e1 = i1.next(), let e2 = i2.next(), isEqual {
-        isEqual = e1 == e2
-    }
-    return isEqual
+
+    return lhs.starts(with: rhs, by: ==)
 }

--- a/Source/RxCharacteristicType.swift
+++ b/Source/RxCharacteristicType.swift
@@ -73,7 +73,7 @@ func == (lhs: [RxCharacteristicType], rhs: [RxCharacteristicType]) -> Bool {
     var i1 = lhs.makeIterator()
     var i2 = rhs.makeIterator()
     var isEqual = true
-    while let e1 = i1.next(), let e2 = i2.next(),  isEqual {
+    while let e1 = i1.next(), let e2 = i2.next(), isEqual {
         isEqual = e1 == e2
     }
     return isEqual

--- a/Source/RxServiceType.swift
+++ b/Source/RxServiceType.swift
@@ -66,11 +66,6 @@ func == (lhs: [RxServiceType], rhs: [RxServiceType]) -> Bool {
     guard lhs.count == rhs.count else {
         return false
     }
-    var i1 = lhs.makeIterator()
-    var i2 = rhs.makeIterator()
-    var isEqual = true
-    while let e1 = i1.next(), let e2 = i2.next(), isEqual {
-        isEqual = e1 == e2
-    }
-    return isEqual
+
+    return lhs.starts(with: rhs, by: ==)
 }


### PR DESCRIPTION
Fixed the RxTest.framework reference (which was still RxTests and it would not build).

Also fixed some swiftlint warnings (mostly whitespace and line_length) and deactivated missing_docs because it is broken in XCode 8 (see https://github.com/realm/SwiftLint/issues/811).

I also changed the array comparison in RxCharacteristicType and RxServiceType to use starts(with:by:) because when the arrays have the same length and one starts with the other they should be equal.