### PR TITLE
Fix BluetoothManager options not being passed to RxCBCentralManager

### DIFF
--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -91,7 +91,7 @@ public class BluetoothManager {
      */
     convenience public init(queue: DispatchQueue = .main,
                             options: [String : AnyObject]? = nil) {
-        self.init(centralManager: RxCBCentralManager(queue: queue),
+        self.init(centralManager: RxCBCentralManager(queue: queue, options: options),
             queueScheduler: ConcurrentDispatchQueueScheduler(queue: queue))
     }
 


### PR DESCRIPTION
I've noticed this warning when using the library:

`[CoreBluetooth] API MISUSE: <private> has no restore identifier but the delegate implements the centralManager:willRestoreState: method. Restoring will not be supported`

Digging a bit, this happens when the `CBCentralManagerOptionRestoreIdentifierKey` is not passed has an option. When actually trying to pass an options dictionary to `BluetoothManager` I noticed this bug.