### PR TITLE
Fix tests for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_script:
         - travis_retry carthage build --platform iOS
 script:
         - set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit iOS" -destination "platform=iOS Simulator,OS=10.0,name=iPhone 7 Plus" ONLY_ACTIVE_ARCH=NO | xcpretty
+        - set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit OSX" ONLY_ACTIVE_ARCH=NO | xcpretty
 
 after_success:
         - sleep 5 # https://github.com/travis-ci/travis-ci/issues/4725

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ osx_image: xcode8
 xcode_project: RxBluetoothKit.xcodeproj
 xcode_sdk: iphonesimulator10.0
 
+env:
+        matrix:
+                - TARGET=iOS
+                - TARGET=macOS
 before_install:
         - brew update
         - brew outdated carthage || brew upgrade carthage
@@ -10,9 +14,7 @@ before_script:
         - carthage checkout --no-use-binaries
         - travis_retry carthage build --platform iOS,macOS
 script:
-        - set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit iOS" -destination "platform=iOS Simulator,OS=10.0,name=iPhone 7 Plus" ONLY_ACTIVE_ARCH=NO | xcpretty
-        - sleep 5
-        - set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit macOS" ONLY_ACTIVE_ARCH=NO | xcpretty
+        ./scripts/all-tests.sh "${TARGET}"
 
 after_success:
         - sleep 5 # https://github.com/travis-ci/travis-ci/issues/4725

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
         - brew outdated carthage || brew upgrade carthage
 before_script:
         - carthage checkout --no-use-binaries
-        - travis_retry carthage build --platform iOS,macOS
+        - travis_retry carthage build --platform "${TARGET}"
 script:
         ./scripts/all-tests.sh "${TARGET}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_script:
         - travis_retry carthage build --platform iOS,macOS
 script:
         - set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit iOS" -destination "platform=iOS Simulator,OS=10.0,name=iPhone 7 Plus" ONLY_ACTIVE_ARCH=NO | xcpretty
+        - sleep 5
         - set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit macOS" ONLY_ACTIVE_ARCH=NO | xcpretty
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ before_install:
         - brew outdated carthage || brew upgrade carthage
 before_script:
         - carthage checkout --no-use-binaries
-        - travis_retry carthage build --platform iOS
+        - travis_retry carthage build --platform iOS,macOS
 script:
         - set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit iOS" -destination "platform=iOS Simulator,OS=10.0,name=iPhone 7 Plus" ONLY_ACTIVE_ARCH=NO | xcpretty
-        - set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit OSX" ONLY_ACTIVE_ARCH=NO | xcpretty
+        - set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit macOS" ONLY_ACTIVE_ARCH=NO | xcpretty
 
 after_success:
         - sleep 5 # https://github.com/travis-ci/travis-ci/issues/4725

--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -156,7 +156,7 @@
 		2666FD841CCE457C005E81CE /* RxBluetoothKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBluetoothKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2666FD8D1CCE457C005E81CE /* RxBluetoothKit iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RxBluetoothKit iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2666FDA31CCE4626005E81CE /* RxBluetoothKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBluetoothKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2666FDAC1CCE4626005E81CE /* RxBluetoothKit OSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RxBluetoothKit OSXTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2666FDAC1CCE4626005E81CE /* RxBluetoothKit macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RxBluetoothKit macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2666FE5A1CCE65CD005E81CE /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = SOURCE_ROOT; };
 		2666FE5E1CCE65EE005E81CE /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/Mac/RxSwift.framework; sourceTree = SOURCE_ROOT; };
 		26EF38C81D86EE1F00F9F468 /* BluetoothState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BluetoothState.swift; sourceTree = "<group>"; };
@@ -371,12 +371,12 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		2666FE5D1CCE65D1005E81CE /* OSX */ = {
+		2666FE5D1CCE65D1005E81CE /* macOS */ = {
 			isa = PBXGroup;
 			children = (
 				2666FE5E1CCE65EE005E81CE /* RxSwift.framework */,
 			);
-			name = OSX;
+			name = macOS;
 			sourceTree = "<group>";
 		};
 		A10F298C1CDCD6EB00593284 /* OSX */ = {
@@ -416,7 +416,7 @@
 				2666FD841CCE457C005E81CE /* RxBluetoothKit.framework */,
 				2666FD8D1CCE457C005E81CE /* RxBluetoothKit iOSTests.xctest */,
 				2666FDA31CCE4626005E81CE /* RxBluetoothKit.framework */,
-				2666FDAC1CCE4626005E81CE /* RxBluetoothKit OSXTests.xctest */,
+				2666FDAC1CCE4626005E81CE /* RxBluetoothKit macOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -437,7 +437,7 @@
 		A1299C8D1CBE433B005DEA5B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				2666FE5D1CCE65D1005E81CE /* OSX */,
+				2666FE5D1CCE65D1005E81CE /* macOS */,
 				2666FE591CCE65A9005E81CE /* iOS */,
 			);
 			name = Frameworks;
@@ -510,9 +510,9 @@
 			productReference = 2666FD8D1CCE457C005E81CE /* RxBluetoothKit iOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		2666FDA21CCE4626005E81CE /* RxBluetoothKit OSX */ = {
+		2666FDA21CCE4626005E81CE /* RxBluetoothKit macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2666FDB41CCE4626005E81CE /* Build configuration list for PBXNativeTarget "RxBluetoothKit OSX" */;
+			buildConfigurationList = 2666FDB41CCE4626005E81CE /* Build configuration list for PBXNativeTarget "RxBluetoothKit macOS" */;
 			buildPhases = (
 				2666FD9E1CCE4626005E81CE /* Sources */,
 				2666FD9F1CCE4626005E81CE /* Frameworks */,
@@ -523,14 +523,14 @@
 			);
 			dependencies = (
 			);
-			name = "RxBluetoothKit OSX";
+			name = "RxBluetoothKit macOS";
 			productName = "RxBluetoothKit OSX";
 			productReference = 2666FDA31CCE4626005E81CE /* RxBluetoothKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		2666FDAB1CCE4626005E81CE /* RxBluetoothKit OSXTests */ = {
+		2666FDAB1CCE4626005E81CE /* RxBluetoothKit macOSTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2666FDB71CCE4626005E81CE /* Build configuration list for PBXNativeTarget "RxBluetoothKit OSXTests" */;
+			buildConfigurationList = 2666FDB71CCE4626005E81CE /* Build configuration list for PBXNativeTarget "RxBluetoothKit macOSTests" */;
 			buildPhases = (
 				2666FDA81CCE4626005E81CE /* Sources */,
 				2666FDA91CCE4626005E81CE /* Frameworks */,
@@ -542,9 +542,9 @@
 			dependencies = (
 				2666FDAF1CCE4626005E81CE /* PBXTargetDependency */,
 			);
-			name = "RxBluetoothKit OSXTests";
+			name = "RxBluetoothKit macOSTests";
 			productName = "RxBluetoothKit OSXTests";
-			productReference = 2666FDAC1CCE4626005E81CE /* RxBluetoothKit OSXTests.xctest */;
+			productReference = 2666FDAC1CCE4626005E81CE /* RxBluetoothKit macOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -587,8 +587,8 @@
 			targets = (
 				2666FD831CCE457C005E81CE /* RxBluetoothKit iOS */,
 				2666FD8C1CCE457C005E81CE /* RxBluetoothKit iOSTests */,
-				2666FDA21CCE4626005E81CE /* RxBluetoothKit OSX */,
-				2666FDAB1CCE4626005E81CE /* RxBluetoothKit OSXTests */,
+				2666FDA21CCE4626005E81CE /* RxBluetoothKit macOS */,
+				2666FDAB1CCE4626005E81CE /* RxBluetoothKit macOSTests */,
 			);
 		};
 /* End PBXProject section */
@@ -738,7 +738,7 @@
 		};
 		2666FDAF1CCE4626005E81CE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 2666FDA21CCE4626005E81CE /* RxBluetoothKit OSX */;
+			target = 2666FDA21CCE4626005E81CE /* RxBluetoothKit macOS */;
 			targetProxy = 2666FDAE1CCE4626005E81CE /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -1037,7 +1037,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		2666FDB41CCE4626005E81CE /* Build configuration list for PBXNativeTarget "RxBluetoothKit OSX" */ = {
+		2666FDB41CCE4626005E81CE /* Build configuration list for PBXNativeTarget "RxBluetoothKit macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2666FDB51CCE4626005E81CE /* Debug */,
@@ -1046,7 +1046,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		2666FDB71CCE4626005E81CE /* Build configuration list for PBXNativeTarget "RxBluetoothKit OSXTests" */ = {
+		2666FDB71CCE4626005E81CE /* Build configuration list for PBXNativeTarget "RxBluetoothKit macOSTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2666FDB81CCE4626005E81CE /* Debug */,

--- a/RxBluetoothKit.xcodeproj/xcshareddata/xcschemes/RxBluetoothKit macOS.xcscheme
+++ b/RxBluetoothKit.xcodeproj/xcshareddata/xcschemes/RxBluetoothKit macOS.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "2666FDA21CCE4626005E81CE"
                BuildableName = "RxBluetoothKit.framework"
-               BlueprintName = "RxBluetoothKit OSX"
+               BlueprintName = "RxBluetoothKit macOS"
                ReferencedContainer = "container:RxBluetoothKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -33,8 +33,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "2666FDAB1CCE4626005E81CE"
-               BuildableName = "RxBluetoothKit OSXTests.xctest"
-               BlueprintName = "RxBluetoothKit OSXTests"
+               BuildableName = "RxBluetoothKit macOSTests.xctest"
+               BlueprintName = "RxBluetoothKit macOSTests"
                ReferencedContainer = "container:RxBluetoothKit.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -44,7 +44,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2666FDA21CCE4626005E81CE"
             BuildableName = "RxBluetoothKit.framework"
-            BlueprintName = "RxBluetoothKit OSX"
+            BlueprintName = "RxBluetoothKit macOS"
             ReferencedContainer = "container:RxBluetoothKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -66,7 +66,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2666FDA21CCE4626005E81CE"
             BuildableName = "RxBluetoothKit.framework"
-            BlueprintName = "RxBluetoothKit OSX"
+            BlueprintName = "RxBluetoothKit macOS"
             ReferencedContainer = "container:RxBluetoothKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -84,7 +84,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2666FDA21CCE4626005E81CE"
             BuildableName = "RxBluetoothKit.framework"
-            BlueprintName = "RxBluetoothKit OSX"
+            BlueprintName = "RxBluetoothKit macOS"
             ReferencedContainer = "container:RxBluetoothKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Tests/FakeCharacteristic.swift
+++ b/Tests/FakeCharacteristic.swift
@@ -27,7 +27,7 @@ import CoreBluetooth
 
 class FakeCharacteristic: RxCharacteristicType {
 
-    var uuid: CBUUID = CBUUID()
+    var uuid: CBUUID = CBUUID(string: "aabb")
     var value: Data? = nil
     var isNotifying: Bool = false
     var properties: CBCharacteristicProperties = .notify

--- a/Tests/FakeService.swift
+++ b/Tests/FakeService.swift
@@ -27,7 +27,7 @@ import CoreBluetooth
 
 class FakeService: RxServiceType {
 
-    var uuid: CBUUID = CBUUID()
+    var uuid: CBUUID = CBUUID(string: "bbaa")
 
     var characteristics: [RxCharacteristicType]? = nil
     var includedServices: [RxServiceType]? = nil

--- a/Tests/PeripheralSpec+Characteristics.swift
+++ b/Tests/PeripheralSpec+Characteristics.swift
@@ -63,7 +63,7 @@ class PeripheralCharacteristicsSpec: QuickSpec {
         describe("characteristic") {
             var identifiers: [CBUUID]!
             beforeEach {
-                identifiers = [CBUUID()]
+                identifiers = [CBUUID(string: "aabb")]
             }
             describe("discover") {
                 var characteristicsDiscoverObservable: ScheduledObservable<[Characteristic]>!

--- a/Tests/PeripheralSpec+Services.swift
+++ b/Tests/PeripheralSpec+Services.swift
@@ -57,7 +57,7 @@ class PeripheralServicesSpec: QuickSpec {
             var cbuuids: [CBUUID]!
 
             beforeEach {
-                cbuuids = [CBUUID()]
+                cbuuids = [CBUUID(string: "bbaa")]
             }
 
             describe("discover") {

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$1" == "iOS" ]; then
+	set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit iOS" -destination "platform=iOS Simulator,OS=10.0,name=iPhone 7 Plus" ONLY_ACTIVE_ARCH=NO | xcpretty
+elif [ "$1" == "macOS" ]; then
+	set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit macOS" ONLY_ACTIVE_ARCH=NO | xcpretty
+else
+	echo "wrong parameters. (iOS|macOS)"
+	exit 1
+fi


### PR DESCRIPTION
In macOS `CBUUID()` initializes a CBUUID with value `Unknown ((null))`,
therefore the tests for discovering service and characteristic failed,
because it searches for the faulty UUIDs.

iOS Playground:
![screen shot 2016-10-28 at 11 59 04](https://cloud.githubusercontent.com/assets/792046/19802926/7096c17e-9d06-11e6-8999-3cba6ee8cf6d.png)

macOS Playground:
![screen shot 2016-10-28 at 12 01 53](https://cloud.githubusercontent.com/assets/792046/19802937/7a5770a0-9d06-11e6-838e-3f6e6a4f1859.png)

This was fixed by setting the UUID in the Fakes and the Tests to a
static one.

I also changed the naming from **OSX** to **macOS** and added the **macOS** tests to the `.travis.yml`

This should fix #23 .
