### PR TITLE
Fix: reading values when multiple services/characteristics used with …

### DIFF
--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -376,11 +376,16 @@ public class Peripheral {
     // MARK: Descriptors
     /**
      Function that triggers descriptors discovery for characteristic
+     If all of the descriptors are already discovered - these are returned without doing any underlying Bluetooth operations.
      - Parameter characteristic: `Characteristic` instance for which descriptors should be discovered.
      - Returns: Observable that emits `Next` with array of `Descriptor` instances, once they're discovered.
      Immediately after that `.Complete` is emitted.
      */
     public func discoverDescriptors(for characteristic: Characteristic) -> Observable<[Descriptor]> {
+        if let descriptors = characteristic.descriptors {
+            let resultDescriptors = descriptors.map { Descriptor(descriptor: $0.descriptor, characteristic: characteristic) }
+            return ensureValidPeripheralState(for: .just(resultDescriptors))
+        }
         let observable = peripheral
             .rx_didDiscoverDescriptorsForCharacteristic
             .filter { $0.0 == characteristic.characteristic }

--- a/Source/RxCBCharacteristic.swift
+++ b/Source/RxCBCharacteristic.swift
@@ -51,4 +51,8 @@ class RxCBCharacteristic: RxCharacteristicType {
         return RxCBService(service: characteristic.service)
     }
 
+    func isEqualTo(characteristic: RxCharacteristicType) -> Bool {
+        guard let rhs = characteristic as? RxCBCharacteristic else { return false }
+        return self.characteristic === rhs.characteristic
+    }
 }

--- a/Source/RxCBDescriptor.swift
+++ b/Source/RxCBDescriptor.swift
@@ -40,4 +40,9 @@ class RxCBDescriptor: RxDescriptorType {
     var value: Any? {
         return descriptor.value
     }
+
+    func isEqualTo(descriptor: RxDescriptorType) -> Bool {
+        guard let rhs = descriptor as? RxCBDescriptor else { return false }
+        return self.descriptor === rhs.descriptor
+    }
 }

--- a/Source/RxCBService.swift
+++ b/Source/RxCBService.swift
@@ -43,4 +43,9 @@ class RxCBService: RxServiceType {
     var isPrimary: Bool {
         return service.isPrimary
     }
+
+    func isEqualTo(service: RxServiceType) -> Bool {
+        guard let rhs = service as? RxCBService else { return false }
+        return self.service === rhs.service
+    }
 }

--- a/Source/RxCharacteristicType.swift
+++ b/Source/RxCharacteristicType.swift
@@ -45,7 +45,12 @@ protocol RxCharacteristicType {
 
     /// Characteristic service
     var service: RxServiceType { get }
+
+    /// True if the two characteristic objects considered equal
+    func isEqualTo(characteristic: RxCharacteristicType) -> Bool
 }
+
+extension Equatable where Self: RxCharacteristicType {}
 
 /**
  Characteristics are equal if their UUIDs are equal
@@ -55,7 +60,7 @@ protocol RxCharacteristicType {
  - returns: True if characteristics are the same
  */
 func == (lhs: RxCharacteristicType, rhs: RxCharacteristicType) -> Bool {
-    return lhs.uuid == rhs.uuid
+    return lhs.isEqualTo(characteristic: rhs)
 }
 
 /**

--- a/Source/RxDescriptorType.swift
+++ b/Source/RxDescriptorType.swift
@@ -36,8 +36,13 @@ protocol RxDescriptorType {
 
     /// Descriptor's value
     var value: Any? { get }
+
+    /// True if the two descriptor objects considered equal
+    func isEqualTo(descriptor: RxDescriptorType) -> Bool
 }
 
+extension Equatable where Self: RxDescriptorType {}
+
 func == (lhs: RxDescriptorType, rhs: RxDescriptorType) -> Bool {
-    return lhs.uuid == rhs.uuid
+    return lhs.isEqualTo(descriptor: rhs)
 }

--- a/Source/RxServiceType.swift
+++ b/Source/RxServiceType.swift
@@ -39,6 +39,10 @@ protocol RxServiceType {
 
     /// True if service is a primary service
     var isPrimary: Bool { get }
+
+    /// True if the two service objects considered equal
+    func isEqualTo(service: RxServiceType) -> Bool
+
 }
 
 extension Equatable where Self: RxServiceType {}
@@ -51,7 +55,7 @@ extension Equatable where Self: RxServiceType {}
  - returns: True if services UUIDs are the same.
  */
 func == (lhs: RxServiceType, rhs: RxServiceType) -> Bool {
-    return lhs.uuid == rhs.uuid
+    return lhs.isEqualTo(service: rhs)
 }
 
 /**

--- a/Tests/FakeCharacteristic.swift
+++ b/Tests/FakeCharacteristic.swift
@@ -40,4 +40,8 @@ class FakeCharacteristic: RxCharacteristicType {
         self.service = service
     }
 
+    func isEqualTo(characteristic: RxCharacteristicType) -> Bool {
+        return uuid == characteristic.uuid
+    }
+
 }

--- a/Tests/FakeDescriptor.swift
+++ b/Tests/FakeDescriptor.swift
@@ -33,4 +33,8 @@ class FakeDescriptor: RxDescriptorType {
     init(characteristic: RxCharacteristicType) {
         self.characteristic = characteristic
     }
+
+    func isEqualTo(descriptor: RxDescriptorType) -> Bool {
+        return uuid == descriptor.uuid
+    }
 }

--- a/Tests/FakeService.swift
+++ b/Tests/FakeService.swift
@@ -32,4 +32,9 @@ class FakeService: RxServiceType {
     var characteristics: [RxCharacteristicType]? = nil
     var includedServices: [RxServiceType]? = nil
     var isPrimary: Bool = false
+
+    func isEqualTo(service: RxServiceType) -> Bool {
+        return uuid == service.uuid
+    }
+
 }


### PR DESCRIPTION
…same UUID (without breaking existing API)

PR is updated!

(See issues: https://github.com/Polidea/RxBluetoothKit/issues/81 and https://github.com/Polidea/RxBluetoothKit/issues/82)

Earlier when discovering services/characteristics UUID comparison was used to
determine for a given service/characteristics if CBPeripheralDelegate callback
was related to a given service/characteristic instance.
It worked only when each service/characteristic had unique UUID.
This approach failed to work when multiple service/characteristic instances used same UUID.
The other issue was that service/characteristics discovery assumed that the result list count
will be the same as the request UUID list count. In practice the result list can be bigger than
the request UUID list because of the possibility of redundant UUIDs.

The commit fixes both issues above:

- Refactored RxServiceType, RxCharacteristicType, RxDescriptorType equality.
Service/Characteristic/Descriptor instances will be considered equal if the the wrapped
CoreBluetooth objects references are equal. This guarantees proper bindings with
CBPeripheralDelegate callbacks with corresponding CoreBluetooth objects.

- Result list count of service/characteristics discoveries filtered based on the original request UUID list

- Some code in unit tests is updated to make sure unit tests are passing


-------

I've created a filter logic that is used to check cached items for discoverServices/discoverIncludedServices/discoverCharacteristics calls. All the unit tests are passing. The template function is filterCachedItems<T>. It would be nice to have additional unit tests for filterCachedItems<T> method but I'm not familiar with QuickSpec way of unit testing. 

I've forced pushed my changes so that you can see easily the diff to the original code.