### PR TITLE
Renaming of `BluetoothManager`. First version of code that allows to share implementation between `Central` and `Peripheral` managers

### DIFF
--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -93,6 +93,9 @@
 		A10F29A51CDCD75900593284 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10F29991CDCD73A00593284 /* Quick.framework */; };
 		A10F29AD1CDCD98400593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5A1CCE65CD005E81CE /* RxSwift.framework */; };
 		A10F29B01CDCD99900593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5E1CCE65EE005E81CE /* RxSwift.framework */; };
+		BB9E4C681E30117E008415CC /* PeripheralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9E4C671E30117E008415CC /* PeripheralManager.swift */; };
+		BB9E4C6B1E3011EF008415CC /* BluetoothStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9E4C6A1E3011EF008415CC /* BluetoothStateManager.swift */; };
+		BB9E4C6C1E3012C6008415CC /* BluetoothStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9E4C6A1E3011EF008415CC /* BluetoothStateManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -188,6 +191,8 @@
 		A1299C221CBE3DEE005DEA5B /* ScanOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanOperation.swift; sourceTree = "<group>"; };
 		A1299C231CBE3DEE005DEA5B /* Service.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		A1299C241CBE3DEE005DEA5B /* Unimplemented.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Unimplemented.swift; sourceTree = "<group>"; };
+		BB9E4C671E30117E008415CC /* PeripheralManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeripheralManager.swift; sourceTree = "<group>"; };
+		BB9E4C6A1E3011EF008415CC /* BluetoothStateManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BluetoothStateManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -424,6 +429,7 @@
 		A1299BD71CBE3D61005DEA5B /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				BB9E4C691E3011DD008415CC /* BluetoothStateManager */,
 				BB9E4C641E301067008415CC /* PeripheralManager */,
 				265CD5FE1CBED348007120AB /* Descriptor */,
 				265CD5FD1CBED33D007120AB /* Peripheral */,
@@ -448,8 +454,17 @@
 		BB9E4C641E301067008415CC /* PeripheralManager */ = {
 			isa = PBXGroup;
 			children = (
+				BB9E4C671E30117E008415CC /* PeripheralManager.swift */,
 			);
 			name = PeripheralManager;
+			sourceTree = "<group>";
+		};
+		BB9E4C691E3011DD008415CC /* BluetoothStateManager */ = {
+			isa = PBXGroup;
+			children = (
+				BB9E4C6A1E3011EF008415CC /* BluetoothStateManager.swift */,
+			);
+			name = BluetoothStateManager;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -659,12 +674,14 @@
 				2666FE401CCE4732005E81CE /* Unimplemented.swift in Sources */,
 				2666FE3B1CCE4732005E81CE /* RxCBService.swift in Sources */,
 				2666FE371CCE4732005E81CE /* DeviceIdentifiers.swift in Sources */,
+				BB9E4C681E30117E008415CC /* PeripheralManager.swift in Sources */,
 				26EF38C91D86EE1F00F9F468 /* BluetoothState.swift in Sources */,
 				2666FE471CCE4732005E81CE /* RxCentralManagerType.swift in Sources */,
 				2666FE301CCE4732005E81CE /* RxDescriptorType.swift in Sources */,
 				2666FE461CCE4732005E81CE /* ScanOperation.swift in Sources */,
 				2666FE3D1CCE4732005E81CE /* RxCBCharacteristic.swift in Sources */,
 				2666FE3C1CCE4732005E81CE /* RxCharacteristicType.swift in Sources */,
+				BB9E4C6B1E3011EF008415CC /* BluetoothStateManager.swift in Sources */,
 				2666FE351CCE4732005E81CE /* Peripheral.swift in Sources */,
 				2666FE331CCE4732005E81CE /* RxPeripheralType.swift in Sources */,
 				2666FE441CCE4732005E81CE /* Boxes.swift in Sources */,
@@ -709,6 +726,7 @@
 				2666FE241CCE4731005E81CE /* Observable+QueueSubscribeOn.swift in Sources */,
 				2666FE2E1CCE4731005E81CE /* BluetoothManager.swift in Sources */,
 				2666FE251CCE4731005E81CE /* Unimplemented.swift in Sources */,
+				BB9E4C6C1E3012C6008415CC /* BluetoothStateManager.swift in Sources */,
 				2666FE201CCE4731005E81CE /* RxCBService.swift in Sources */,
 				2666FE1C1CCE4731005E81CE /* DeviceIdentifiers.swift in Sources */,
 				2666FE2C1CCE4731005E81CE /* RxCentralManagerType.swift in Sources */,

--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -424,6 +424,7 @@
 		A1299BD71CBE3D61005DEA5B /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				BB9E4C641E301067008415CC /* PeripheralManager */,
 				265CD5FE1CBED348007120AB /* Descriptor */,
 				265CD5FD1CBED33D007120AB /* Peripheral */,
 				265CD5FC1CBED339007120AB /* Service */,
@@ -442,6 +443,13 @@
 			);
 			name = Frameworks;
 			path = RxBluetoothKit;
+			sourceTree = "<group>";
+		};
+		BB9E4C641E301067008415CC /* PeripheralManager */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = PeripheralManager;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -193,7 +193,7 @@ public class CentralManager: BluetoothStateManager {
                 return self.ensure(.poweredOn, observable: observable)
             }
     }
-    
+
     // MARK: Peripheral's Connection Management
 
     /**

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -51,10 +51,6 @@ public class CentralManager: BluetoothStateManager {
     /// Implementation of Central Manager
     private let centralManager: RxCentralManagerType
 
-    var stateProvider: BluetoothStateProvider {
-        return centralManager
-    }
-
     /// Queue on which all observables are serialised if needed
     private let subscriptionQueue: SerializedSubscriptionQueue
 
@@ -63,6 +59,16 @@ public class CentralManager: BluetoothStateManager {
 
     /// Queue of scan operations which are waiting for an execution
     private var scanQueue: [ScanOperation] = []
+
+    /// Observable which emits state changes of central manager after subscriptions
+    var rx_didUpdateState: Observable<BluetoothState> {
+        return centralManager.rx_didUpdateState
+    }
+
+    /// Current state of Central Manager
+    var state: BluetoothState {
+        return centralManager.state
+    }
 
     // MARK: Initialization
 
@@ -110,7 +116,7 @@ public class CentralManager: BluetoothStateManager {
      Scans by default are infinite streams of `ScannedPeripheral` structures which need to be stopped by the user. For
      example this can be done by limiting scanning to certain number of peripherals or time:
 
-     CentralManager.scanForPeripherals(withServices: nil)
+     centralManager.scanForPeripherals(withServices: nil)
         .timeout(3.0, timeoutScheduler)
         .take(2)
 

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -27,15 +27,15 @@ import CoreBluetooth
 // swiftlint:disable line_length
 
 /**
- BluetoothManager is a class implementing ReactiveX API which wraps all Core Bluetooth Manager's functions allowing to
+ CentralManager is a class implementing ReactiveX API which wraps all Core Bluetooth Manager's functions allowing to
  discover, connect to remote peripheral devices and more. It's using thin layer behind `RxCentralManagerType` protocol which is
  implemented by `RxCBCentralManager` and should not be used directly by the user of a RxBluetoothKit library.
 
  You can start using this class by discovering available services of nearby peripherals. Before calling any
- public `BluetoothManager`'s functions you should make sure that Bluetooth is turned on and powered on. It can be done
+ public `CentralManager`'s functions you should make sure that Bluetooth is turned on and powered on. It can be done
  by calling and observing returned value of `monitorState()` and then chaining it with `scanForPeripherals(_:options:)`:
 
- bluetoothManager.rx_state
+ CentralManager.rx_state
  .filter { $0 == .PoweredOn }
  .take(1)
  .flatMap { manager.scanForPeripherals(nil) }
@@ -46,7 +46,7 @@ import CoreBluetooth
  - seealso: `Peripheral`
  */
 
-public class BluetoothManager {
+public class CentralManager {
 
     /// Implementation of Central Manager
     private let centralManager: RxCentralManagerType
@@ -63,7 +63,7 @@ public class BluetoothManager {
     // MARK: Initialization
 
     /**
-     Creates new `BluetoothManager` instance with specified implementation of `RxCentralManagerType` protocol which will be
+     Creates new `CentralManager` instance with specified implementation of `RxCentralManagerType` protocol which will be
      used by this class. Most of a time `RxCBCentralManager` should be chosen by the user.
 
      - parameter centralManager: Implementation of `RxCentralManagerType` protocol used by this class.
@@ -77,7 +77,7 @@ public class BluetoothManager {
     }
 
     /**
-     Creates new `BluetoothManager` instance. By default all operations and events are executed and received on
+     Creates new `CentralManager` instance. By default all operations and events are executed and received on
      main thread.
 
      - warning: If you pass background queue to the method make sure to observe results on main thread for UI related
@@ -106,7 +106,7 @@ public class BluetoothManager {
      Scans by default are infinite streams of `ScannedPeripheral` structures which need to be stopped by the user. For
      example this can be done by limiting scanning to certain number of peripherals or time:
 
-     bluetoothManager.scanForPeripherals(withServices: nil)
+     CentralManager.scanForPeripherals(withServices: nil)
         .timeout(3.0, timeoutScheduler)
         .take(2)
 
@@ -193,7 +193,7 @@ public class BluetoothManager {
     // MARK: State
 
     /**
-     Continuous state of `BluetoothManager` instance described by `BluetoothState` which is equivalent to  [`CBManagerState`](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
+     Continuous state of `CentralManager` instance described by `BluetoothState` which is equivalent to  [`CBManagerState`](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
 
      - returns: Observable that emits `Next` immediately after subscribtion with current state of Bluetooth. Later,
      whenever state changes events are emitted. Observable is infinite : doesn't generate `Complete`.
@@ -205,9 +205,9 @@ public class BluetoothManager {
     }
 
     /**
-     Current state of `BluetoothManager` instance described by `BluetoothState` which is equivalent to [`CBManagerState`](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
+     Current state of `CentralManager` instance described by `BluetoothState` which is equivalent to [`CBManagerState`](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
 
-     - returns: Current state of `BluetoothManager` as `BluetoothState`.
+     - returns: Current state of `CentralManager` as `BluetoothState`.
      */
 
     public var state: BluetoothState {
@@ -224,7 +224,7 @@ public class BluetoothManager {
      Additionally you can pass optional [dictionary](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/#//apple_ref/doc/constant_group/Peripheral_Connection_Options)
      to customise the behaviour of connection.
 
-     - parameter peripheral: The `Peripheral` to which `BluetoothManager` is attempting to connect.
+     - parameter peripheral: The `Peripheral` to which `CentralManager` is attempting to connect.
      - parameter options: Dictionary to customise the behaviour of connection.
      - returns: Observable which emits next and complete events after connection is established.
      */
@@ -274,7 +274,7 @@ public class BluetoothManager {
      Cancels an active or pending local connection to a `Peripheral` after observable subscription. It is not guaranteed
      that physical connection will be closed immediately as well and all pending commands will not be executed.
 
-     - parameter peripheral: The `Peripheral` to which the `BluetoothManager` is either trying to
+     - parameter peripheral: The `Peripheral` to which the `CentralManager` is either trying to
      connect or has already connected.
      - returns: Observable which emits next and complete events when peripheral successfully cancelled connection.
      */
@@ -290,7 +290,7 @@ public class BluetoothManager {
     // MARK: Retrieving Lists of Peripherals
 
     /**
-     Returns observable list of the `Peripheral`s which are currently connected to the `BluetoothManager` and contain
+     Returns observable list of the `Peripheral`s which are currently connected to the `CentralManager` and contain
      all of the specified `Service`'s UUIDs.
 
      - parameter serviceUUIDs: A list of `Service` UUIDs
@@ -310,7 +310,7 @@ public class BluetoothManager {
     }
 
     /**
-     Returns observable list of `Peripheral`s by their identifiers which are known to `BluetoothManager`.
+     Returns observable list of `Peripheral`s by their identifiers which are known to `CentralManager`.
 
      - parameter identifiers: List of `Peripheral`'s identifiers which should be retrieved.
      - returns: Observable which emits next and complete events when list of `Peripheral`s are retrieved.
@@ -330,7 +330,7 @@ public class BluetoothManager {
     // MARK: Internal functions
 
     /**
-     Ensure that `state` is and will be the only state of `BluetoothManager` during subscription.
+     Ensure that `state` is and will be the only state of `CentralManager` during subscription.
      Otherwise error is emitted.
 
      - parameter state: `BluetoothState` which should be present during subscription.
@@ -395,14 +395,14 @@ public class BluetoothManager {
 
     #if os(iOS)
     /**
-     Emits `RestoredState` instance, when state of `BluetoothManager` has been restored
+     Emits `RestoredState` instance, when state of `CentralManager` has been restored
      - Returns: Observable which emits next events state has been restored
      */
     public func listenOnRestoredState() -> Observable<RestoredState> {
         return centralManager
             .rx_willRestoreState
             .take(1)
-            .map { RestoredState(restoredStateDictionary: $0, bluetoothManager: self) }
+            .map { RestoredState(restoredStateDictionary: $0, centralManager: self) }
     }
     #endif
 }

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -46,10 +46,14 @@ import CoreBluetooth
  - seealso: `Peripheral`
  */
 
-public class CentralManager {
+public class CentralManager: BluetoothStateManager {
 
     /// Implementation of Central Manager
     private let centralManager: RxCentralManagerType
+
+    var stateProvider: BluetoothStateProvider {
+        return centralManager
+    }
 
     /// Queue on which all observables are serialised if needed
     private let subscriptionQueue: SerializedSubscriptionQueue
@@ -189,30 +193,7 @@ public class CentralManager {
                 return self.ensure(.poweredOn, observable: observable)
             }
     }
-
-    // MARK: State
-
-    /**
-     Continuous state of `CentralManager` instance described by `BluetoothState` which is equivalent to  [`CBManagerState`](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
-
-     - returns: Observable that emits `Next` immediately after subscribtion with current state of Bluetooth. Later,
-     whenever state changes events are emitted. Observable is infinite : doesn't generate `Complete`.
-     */
-    public var rx_state: Observable<BluetoothState> {
-        return .deferred {
-            return self.centralManager.rx_didUpdateState.startWith(self.centralManager.state)
-        }
-    }
-
-    /**
-     Current state of `CentralManager` instance described by `BluetoothState` which is equivalent to [`CBManagerState`](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
-
-     - returns: Current state of `CentralManager` as `BluetoothState`.
-     */
-
-    public var state: BluetoothState {
-        return centralManager.state
-    }
+    
     // MARK: Peripheral's Connection Management
 
     /**

--- a/Source/BluetoothStateManager.swift
+++ b/Source/BluetoothStateManager.swift
@@ -1,15 +1,15 @@
 import RxSwift
 
 protocol BluetoothStateProvider {
+
+}
+
+protocol BluetoothStateManager {
     /// Observable which emits state changes of central manager after subscriptions
     var rx_didUpdateState: Observable<BluetoothState> { get }
 
     /// Current state of Central Manager
     var state: BluetoothState { get }
-}
-
-protocol BluetoothStateManager {
-    var stateProvider: BluetoothStateProvider { get }
 }
 
 extension BluetoothStateManager {
@@ -25,7 +25,7 @@ extension BluetoothStateManager {
      */
     public var rx_state: Observable<BluetoothState> {
         return .deferred {
-            return self.stateProvider.rx_didUpdateState.startWith(self.stateProvider.state)
+            return self.rx_didUpdateState.startWith(self.state)
         }
     }
 
@@ -37,6 +37,6 @@ extension BluetoothStateManager {
      */
 
     public var state: BluetoothState {
-        return self.stateProvider.state
+        return self.state
     }
 }

--- a/Source/BluetoothStateManager.swift
+++ b/Source/BluetoothStateManager.swift
@@ -1,0 +1,40 @@
+import RxSwift
+
+protocol BluetoothStateProvider {
+    /// Observable which emits state changes of central manager after subscriptions
+    var rx_didUpdateState: Observable<BluetoothState> { get }
+
+    /// Current state of Central Manager
+    var state: BluetoothState { get }
+}
+
+protocol BluetoothStateManager {
+    var stateProvider: BluetoothStateProvider { get }
+}
+
+extension BluetoothStateManager {
+    // MARK: State
+
+    //TODO: Docs to change...
+    /**
+     Continuous state of `CentralManager` instance described by `BluetoothState` which is equivalent to  [`CBManagerState`](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
+
+     - returns: Observable that emits `Next` immediately after subscribtion with current state of Bluetooth. Later,
+     whenever state changes events are emitted. Observable is infinite : doesn't generate `Complete`.
+     */
+    public var rx_state: Observable<BluetoothState> {
+        return .deferred {
+            return self.stateProvider.rx_didUpdateState.startWith(self.stateProvider.state)
+        }
+    }
+
+    /**
+     Current state of `CentralManager` instance described by `BluetoothState` which is equivalent to [`CBManagerState`](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
+
+     - returns: Current state of `CentralManager` as `BluetoothState`.
+     */
+
+    public var state: BluetoothState {
+        return self.stateProvider.state
+    }
+}

--- a/Source/BluetoothStateManager.swift
+++ b/Source/BluetoothStateManager.swift
@@ -17,7 +17,8 @@ extension BluetoothStateManager {
 
     //TODO: Docs to change...
     /**
-     Continuous state of `CentralManager` instance described by `BluetoothState` which is equivalent to  [`CBManagerState`](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
+     Continuous state of `CentralManager` instance described by `BluetoothState` which is equivalent to  
+     [`CBManagerState`](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
 
      - returns: Observable that emits `Next` immediately after subscribtion with current state of Bluetooth. Later,
      whenever state changes events are emitted. Observable is infinite : doesn't generate `Complete`.
@@ -29,7 +30,8 @@ extension BluetoothStateManager {
     }
 
     /**
-     Current state of `CentralManager` instance described by `BluetoothState` which is equivalent to [`CBManagerState`](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
+     Current state of `CentralManager` instance described by `BluetoothState` which is equivalent to 
+     [`CBManagerState`](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
 
      - returns: Current state of `CentralManager` as `BluetoothState`.
      */

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -31,9 +31,9 @@ import CoreBluetooth
  allowing to talk to peripheral like discovering characteristics, services and all of the read/write calls.
  */
 public class Peripheral {
-    let manager: BluetoothManager
+    let manager: CentralManager
 
-    init(manager: BluetoothManager, peripheral: RxPeripheralType) {
+    init(manager: CentralManager, peripheral: RxPeripheralType) {
         self.manager = manager
         self.peripheral = peripheral
     }
@@ -93,8 +93,8 @@ public class Peripheral {
 
     /**
      Establishes local connection to the peripheral.
-     For more information look into `BluetoothManager.connectToPeripheral(_:options:)` because this method calls it directly.
-     - Parameter peripheral: The `Peripheral` to which `BluetoothManager` is attempting to connect.
+     For more information look into `CentralManager.connectToPeripheral(_:options:)` because this method calls it directly.
+     - Parameter peripheral: The `Peripheral` to which `CentralManager` is attempting to connect.
      - Parameter options: Dictionary to customise the behaviour of connection.
      - Returns: Observation which emits next event after connection is established
      */

--- a/Source/PeripheralManager.swift
+++ b/Source/PeripheralManager.swift
@@ -1,0 +1,13 @@
+//
+//  PeripheralManager.swift
+//  RxBluetoothKit
+//
+//  Created by Kacper Harasim on 18.01.2017.
+//  Copyright © 2017 Polidea. All rights reserved.
+//
+
+import Foundation
+
+final class PeripheralManager {
+
+}

--- a/Source/PeripheralManager.swift
+++ b/Source/PeripheralManager.swift
@@ -1,13 +1,3 @@
-//
-//  PeripheralManager.swift
-//  RxBluetoothKit
-//
-//  Created by Kacper Harasim on 18.01.2017.
-//  Copyright © 2017 Polidea. All rights reserved.
-//
-
 import Foundation
 
-final class PeripheralManager {
-
-}
+final class PeripheralManager { }

--- a/Source/RestoredState.swift
+++ b/Source/RestoredState.swift
@@ -24,7 +24,7 @@ import Foundation
 import CoreBluetooth
 
 /**
- Convenience class which helps reading state of restored BluetoothManager
+ Convenience class which helps reading state of restored CentralManager
  */
 #if os(iOS)
 public struct RestoredState {
@@ -34,15 +34,15 @@ public struct RestoredState {
     */
     public let restoredStateData: [String:Any]
 
-    public unowned let bluetoothManager: BluetoothManager
+    public unowned let centralManager: CentralManager
     /**
      Creates restored state information based on CoreBluetooth's dictionary
      - parameter restoredState: Core Bluetooth's restored state data
-     - parameter bluetoothManager: `BluetoothManager` instance of which state has been restored.
+     - parameter centralManager: `CentralManager` instance of which state has been restored.
      */
-    init(restoredStateDictionary: [String:Any], bluetoothManager: BluetoothManager) {
+    init(restoredStateDictionary: [String:Any], centralManager: CentralManager) {
         self.restoredStateData = restoredStateDictionary
-        self.bluetoothManager = bluetoothManager
+        self.centralManager = centralManager
     }
 
     /**
@@ -55,7 +55,7 @@ public struct RestoredState {
         guard let arrayOfAnyObjects = objects else { return [] }
         return arrayOfAnyObjects.flatMap { $0 as? CBPeripheral }
             .map { RxCBPeripheral(peripheral: $0) }
-            .map { Peripheral(manager: bluetoothManager, peripheral: $0) }
+            .map { Peripheral(manager: centralManager, peripheral: $0) }
     }
 
     /**
@@ -75,7 +75,7 @@ public struct RestoredState {
         guard let arrayOfAnyObjects = objects else { return [] }
         return arrayOfAnyObjects.flatMap { $0 as? CBService }
             .map { RxCBService(service: $0) }
-            .map { Service(peripheral: Peripheral(manager: bluetoothManager,
+            .map { Service(peripheral: Peripheral(manager: centralManager,
                 peripheral: RxCBPeripheral(peripheral: $0.service.peripheral)), service: $0) }
     }
 }

--- a/Source/RxCBCentralManager.swift
+++ b/Source/RxCBCentralManager.swift
@@ -34,7 +34,7 @@ class RxCBCentralManager: RxCentralManagerType {
     private let internalDelegate = InternalDelegate()
 
     /**
-     Create Core Bluetooth implementation of RxCentralManagerType which is used by BluetoothManager class.
+     Create Core Bluetooth implementation of RxCentralManagerType which is used by CentralManager class.
      User can specify on which thread all bluetooth events are collected.
 
      - parameter queue: Dispatch queue on which callbacks are received.

--- a/Source/RxCentralManagerType.swift
+++ b/Source/RxCentralManagerType.swift
@@ -25,7 +25,7 @@ import RxSwift
 import CoreBluetooth
 
 /**
- Protocol which wraps Central Manager for bluetooth devices. It is used directly by BluetoothManager
+ Protocol which wraps Central Manager for bluetooth devices. It is used directly by CentralManager
 */
 protocol RxCentralManagerType {
 

--- a/Source/RxCentralManagerType.swift
+++ b/Source/RxCentralManagerType.swift
@@ -27,7 +27,7 @@ import CoreBluetooth
 /**
  Protocol which wraps Central Manager for bluetooth devices. It is used directly by CentralManager
 */
-protocol RxCentralManagerType {
+protocol RxCentralManagerType: BluetoothStateProvider {
 
     /// Observable which emits state changes of central manager after subscriptions
     var rx_didUpdateState: Observable<BluetoothState> { get }

--- a/Tests/BluetoothManagerSpec+Scanning.swift
+++ b/Tests/BluetoothManagerSpec+Scanning.swift
@@ -29,11 +29,11 @@ import RxBluetoothKit
 import RxTest
 import RxSwift
 
-class BluetoothManagerScanningSpec: QuickSpec {
+class CentralManagerScanningSpec: QuickSpec {
     
     override func spec() {
         
-        var manager: BluetoothManager!
+        var manager: CentralManager!
         var fakeCentralManager: FakeCentralManager!
         var testScheduler: TestScheduler!
         var fakePeripheral: FakePeripheral!
@@ -42,7 +42,7 @@ class BluetoothManagerScanningSpec: QuickSpec {
             fakePeripheral = FakePeripheral()
             fakeCentralManager = FakeCentralManager()
             testScheduler = TestScheduler(initialClock: 0, resolution: 1.0, simulateProcessingDelay: false)
-            manager = BluetoothManager(centralManager: fakeCentralManager, queueScheduler: testScheduler)
+            manager = CentralManager(centralManager: fakeCentralManager, queueScheduler: testScheduler)
         }
         
         describe("scanning devices") {

--- a/Tests/BluetoothManagerSpec.swift
+++ b/Tests/BluetoothManagerSpec.swift
@@ -28,10 +28,10 @@ import RxBluetoothKit
 import RxTest
 import RxSwift
 
-class BluetoothManagerSpec: QuickSpec {
+class CentralManagerSpec: QuickSpec {
     override func spec() {
 
-        var manager: BluetoothManager!
+        var manager: CentralManager!
         var fakeCentralManager: FakeCentralManager!
         var testScheduler: TestScheduler!
         var fakePeripheral: FakePeripheral!
@@ -42,7 +42,7 @@ class BluetoothManagerSpec: QuickSpec {
         beforeEach {
             fakePeripheral = FakePeripheral()
             fakeCentralManager = FakeCentralManager()
-            manager = BluetoothManager(centralManager: fakeCentralManager)
+            manager = CentralManager(centralManager: fakeCentralManager)
             testScheduler = TestScheduler(initialClock: 0, resolution: 1.0, simulateProcessingDelay: false)
             nextTime = 230
             errorTime = 240

--- a/Tests/PeripheralSpec+Characteristics.swift
+++ b/Tests/PeripheralSpec+Characteristics.swift
@@ -33,7 +33,7 @@ class PeripheralCharacteristicsSpec: QuickSpec {
 
     override func spec() {
 
-        var manager: BluetoothManager!
+        var manager: CentralManager!
         var fakeCentralManager: FakeCentralManager!
         var testScheduler: TestScheduler!
         var fakePeripheral: FakePeripheral!
@@ -50,7 +50,7 @@ class PeripheralCharacteristicsSpec: QuickSpec {
             testScheduler = TestScheduler(initialClock: 0)
             fakePeripheral = FakePeripheral()
             fakeCentralManager = FakeCentralManager()
-            manager = BluetoothManager(centralManager: fakeCentralManager)
+            manager = CentralManager(centralManager: fakeCentralManager)
             peripheral = Peripheral(manager: manager, peripheral: fakePeripheral)
             fakeService = FakeService()
             service = Service(peripheral: peripheral, service: fakeService)

--- a/Tests/PeripheralSpec+Services.swift
+++ b/Tests/PeripheralSpec+Services.swift
@@ -33,7 +33,7 @@ class PeripheralServicesSpec: QuickSpec {
 
     override func spec() {
 
-        var manager: BluetoothManager!
+        var manager: CentralManager!
         var fakeCentralManager: FakeCentralManager!
         var testScheduler: TestScheduler!
         var fakePeripheral: FakePeripheral!
@@ -46,7 +46,7 @@ class PeripheralServicesSpec: QuickSpec {
             testScheduler = TestScheduler(initialClock: 0)
             fakePeripheral = FakePeripheral()
             fakeCentralManager = FakeCentralManager()
-            manager = BluetoothManager(centralManager: fakeCentralManager)
+            manager = CentralManager(centralManager: fakeCentralManager)
             peripheral = Peripheral(manager: manager, peripheral: fakePeripheral)
             fakeService = FakeService()
         }


### PR DESCRIPTION
I've renamed `BluetoothManager` into `CentralManager.
Also, it appears that the only code that `Central` shares with `Peripheral` in `CoreBluetooth` is the state managing code. I've decided to move this logic to the extension of new protocol `BluetoothStateManager` that by design should be adopted by `Central` and `Peripheral`.

Created empty stub of `PeripheralManager`.