### PR TITLE
Update to RxSwift 3.2 and some cleanup

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v5.1.1"
 github "Quick/Quick" "v0.10.0"
-github "ReactiveX/RxSwift" "3.1.0"
+github "ReactiveX/RxSwift" "3.2.0"

--- a/Source/AdvertisementData.swift
+++ b/Source/AdvertisementData.swift
@@ -55,7 +55,7 @@ public struct AdvertisementData {
      representing service-specific data.
     */
     public var serviceData: [CBUUID:Data]? {
-        return advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID:Data]
+        return advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID: Data]
     }
 
     /// An array of service UUIDs.

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -71,7 +71,7 @@ public class BluetoothManager {
      main thread is used.
      */
     init(centralManager: RxCentralManagerType,
-        queueScheduler: SchedulerType = ConcurrentMainScheduler.instance) {
+         queueScheduler: SchedulerType = ConcurrentMainScheduler.instance) {
             self.centralManager = centralManager
             self.subscriptionQueue = SerializedSubscriptionQueue(scheduler: queueScheduler)
     }

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -239,7 +239,7 @@ public class BluetoothManager {
             let error = centralManager.rx_didFailToConnectPeripheral
                 .filter { $0.0 == peripheral.peripheral }
                 .take(1)
-                .flatMap { (peripheral, error) -> Observable<Peripheral> in
+                .map { (peripheral, error) -> Peripheral in
                     throw BluetoothError.peripheralConnectionFailed(Peripheral(manager: self, peripheral: peripheral), error)
                 }
 
@@ -357,7 +357,7 @@ public class BluetoothManager {
             }
             return self.centralManager.rx_didDisconnectPeripheral
                 .filter { $0.0 == peripheral.peripheral }
-                .flatMap { (_, error) -> Observable<T> in
+                .map { (_, error) -> T in
                     throw BluetoothError.peripheralDisconnected(peripheral, error)
             }
         }

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -89,7 +89,7 @@ public class BluetoothManager {
      For more info about it please refer to [`Central Manager initialization options`](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/index.html)
      */
     convenience public init(queue: DispatchQueue = .main,
-                            options: [String : AnyObject]? = nil) {
+                            options: [String: AnyObject]? = nil) {
         self.init(centralManager: RxCBCentralManager(queue: queue, options: options),
             queueScheduler: ConcurrentDispatchQueueScheduler(queue: queue))
     }

--- a/Source/Observable+QueueSubscribeOn.swift
+++ b/Source/Observable+QueueSubscribeOn.swift
@@ -76,7 +76,6 @@ protocol DelayedObservableType: class {
 }
 
 class QueueSubscribeOn<Element>: Cancelable, ObservableType, ObserverType, DelayedObservableType {
-    typealias E = Element
 
     let source: Observable<Element>
     let queue: SerializedSubscriptionQueue
@@ -112,12 +111,10 @@ class QueueSubscribeOn<Element>: Cancelable, ObservableType, ObserverType, Delay
     func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
         if !CurrentThreadScheduler.isScheduleRequired {
             return run(observer: observer)
-        } else {
-            return CurrentThreadScheduler.instance.schedule(()) { _ in
-                return self.run(observer: observer)
-            }
         }
-
+        return CurrentThreadScheduler.instance.schedule(()) { _ in
+            return self.run(observer: observer)
+        }
     }
 
     // After original subscription we need to place it on queue for delayed execution if required.

--- a/Source/Peripheral+Convenience.swift
+++ b/Source/Peripheral+Convenience.swift
@@ -125,7 +125,7 @@ extension Peripheral {
      if everything completed successfully. Errors are not emitted
      */
     public func writeValue(_ data: Data, for identifier: CharacteristicIdentifier,
-                    type: CBCharacteristicWriteType) -> Observable<Characteristic> {
+                           type: CBCharacteristicWriteType) -> Observable<Characteristic> {
         return characteristic(with: identifier)
             .flatMap { return self.writeValue(data, for: $0, type: type) }
     }

--- a/Source/Peripheral+Convenience.swift
+++ b/Source/Peripheral+Convenience.swift
@@ -63,10 +63,9 @@ extension Peripheral {
                         $0.uuid == identifier.uuid
                     }) {
                         return .just(characteristic)
-                    } else {
-                        return service.discoverCharacteristics([identifier.uuid])
-                            .flatMap { Observable.from($0) }
                     }
+                    return service.discoverCharacteristics([identifier.uuid])
+                        .flatMap { Observable.from($0) }
                 }
         }
     }
@@ -86,12 +85,11 @@ extension Peripheral {
                     if let descriptors = characteristic.descriptors,
                         let descriptor = descriptors.first(where: { $0.uuid == identifier.uuid }) {
                         return .just(descriptor)
-                    } else {
-                        return characteristic.discoverDescriptors()
-                            .flatMap { Observable.from($0) }
-                            .filter { $0.uuid == identifier.uuid }
-                            .take(1)
                     }
+                    return characteristic.discoverDescriptors()
+                        .flatMap { Observable.from($0) }
+                        .filter { $0.uuid == identifier.uuid }
+                        .take(1)
                 }
         }
     }
@@ -127,7 +125,7 @@ extension Peripheral {
     public func writeValue(_ data: Data, for identifier: CharacteristicIdentifier,
                            type: CBCharacteristicWriteType) -> Observable<Characteristic> {
         return characteristic(with: identifier)
-            .flatMap { return self.writeValue(data, for: $0, type: type) }
+            .flatMap { self.writeValue(data, for: $0, type: type) }
     }
 
     /**
@@ -166,7 +164,7 @@ extension Peripheral {
     public func setNotifyValue(_ enabled: Bool, for identifier: CharacteristicIdentifier)
         -> Observable<Characteristic> {
             return characteristic(with: identifier)
-                .flatMap { return self.setNotifyValue(enabled, for: $0) }
+                .flatMap { self.setNotifyValue(enabled, for: $0) }
     }
 
     /**
@@ -216,7 +214,7 @@ extension Peripheral {
     public func writeValue(_ data: Data, for identifier: DescriptorIdentifier)
         -> Observable<Descriptor> {
         return descriptor(with: identifier)
-            .flatMap { return self.writeValue(data, for: $0) }
+            .flatMap { self.writeValue(data, for: $0) }
     }
 
     /**

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -275,8 +275,8 @@ public class Peripheral {
      if everything completed successfully. Errors are not emitted
      */
     public func writeValue(_ data: Data,
-        for characteristic: Characteristic,
-        type: CBCharacteristicWriteType) -> Observable<Characteristic> {
+                           for characteristic: Characteristic,
+                           type: CBCharacteristicWriteType) -> Observable<Characteristic> {
             return .create { observer in
                 let disposable: Disposable
                 switch type {
@@ -337,7 +337,7 @@ public class Peripheral {
      is emitted
      */
     public func setNotifyValue(_ enabled: Bool,
-        for characteristic: Characteristic) -> Observable<Characteristic> {
+                               for characteristic: Characteristic) -> Observable<Characteristic> {
             let observable = peripheral
                 .rx_didUpdateNotificationStateForCharacteristic
                 .filter { $0.0 == characteristic.characteristic }

--- a/Source/RestoredState.swift
+++ b/Source/RestoredState.swift
@@ -32,7 +32,7 @@ public struct RestoredState {
     /**
     Restored state dictionary
     */
-    public let restoredStateData: [String:Any]
+    public let restoredStateData: [String: Any]
 
     public unowned let bluetoothManager: BluetoothManager
     /**
@@ -40,7 +40,7 @@ public struct RestoredState {
      - parameter restoredState: Core Bluetooth's restored state data
      - parameter bluetoothManager: `BluetoothManager` instance of which state has been restored.
      */
-    init(restoredStateDictionary: [String:Any], bluetoothManager: BluetoothManager) {
+    init(restoredStateDictionary: [String: Any], bluetoothManager: BluetoothManager) {
         self.restoredStateData = restoredStateDictionary
         self.bluetoothManager = bluetoothManager
     }
@@ -54,7 +54,7 @@ public struct RestoredState {
         let objects = restoredStateData[CBCentralManagerRestoredStatePeripheralsKey] as? [AnyObject]
         guard let arrayOfAnyObjects = objects else { return [] }
         return arrayOfAnyObjects.flatMap { $0 as? CBPeripheral }
-            .map { RxCBPeripheral(peripheral: $0) }
+            .map(RxCBPeripheral.init)
             .map { Peripheral(manager: bluetoothManager, peripheral: $0) }
     }
 
@@ -62,8 +62,8 @@ public struct RestoredState {
      Dictionary that contains all of the peripheral scan options that were being used
      by the central manager at the time the app was terminated by the system.
     */
-    public var scanOptions: [String : AnyObject]? {
-        return restoredStateData[CBCentralManagerRestoredStatePeripheralsKey] as? [String : AnyObject]
+    public var scanOptions: [String: AnyObject]? {
+        return restoredStateData[CBCentralManagerRestoredStatePeripheralsKey] as? [String: AnyObject]
     }
 
     /**
@@ -74,7 +74,7 @@ public struct RestoredState {
         let objects = restoredStateData[CBCentralManagerRestoredStateScanServicesKey] as? [AnyObject]
         guard let arrayOfAnyObjects = objects else { return [] }
         return arrayOfAnyObjects.flatMap { $0 as? CBService }
-            .map { RxCBService(service: $0) }
+            .map(RxCBService.init)
             .map { Service(peripheral: Peripheral(manager: bluetoothManager,
                 peripheral: RxCBPeripheral(peripheral: $0.service.peripheral)), service: $0) }
     }

--- a/Source/RxCBCentralManager.swift
+++ b/Source/RxCBCentralManager.swift
@@ -61,9 +61,9 @@ class RxCBCentralManager: RxCentralManagerType {
         }
 
         @objc func centralManager(_ central: CBCentralManager,
-            didDiscover peripheral: CBPeripheral,
-            advertisementData: [String: Any],
-            rssi: NSNumber) {
+                                  didDiscover peripheral: CBPeripheral,
+                                  advertisementData: [String: Any],
+                                  rssi: NSNumber) {
                 didDiscoverPeripheralSubject.onNext((RxCBPeripheral(peripheral: peripheral), advertisementData, rssi))
         }
 
@@ -72,14 +72,14 @@ class RxCBCentralManager: RxCentralManagerType {
         }
 
         @objc func centralManager(_ central: CBCentralManager,
-            didFailToConnect peripheral: CBPeripheral,
-            error: Error?) {
+                                  didFailToConnect peripheral: CBPeripheral,
+                                  error: Error?) {
                 didFailToConnectPeripheralSubject.onNext((RxCBPeripheral(peripheral: peripheral), error))
         }
 
         @objc func centralManager(_ central: CBCentralManager,
-            didDisconnectPeripheral peripheral: CBPeripheral,
-            error: Error?) {
+                                  didDisconnectPeripheral peripheral: CBPeripheral,
+                                  error: Error?) {
                 didDisconnectPeripheral.onNext((RxCBPeripheral(peripheral: peripheral), error))
         }
     }

--- a/Source/RxCBCentralManager.swift
+++ b/Source/RxCBCentralManager.swift
@@ -39,7 +39,7 @@ class RxCBCentralManager: RxCentralManagerType {
 
      - parameter queue: Dispatch queue on which callbacks are received.
      */
-    init(queue: DispatchQueue, options: [String : AnyObject]? = nil) {
+    init(queue: DispatchQueue, options: [String: AnyObject]? = nil) {
         centralManager = CBCentralManager(delegate: internalDelegate, queue: queue, options: options)
     }
 
@@ -56,7 +56,7 @@ class RxCBCentralManager: RxCentralManagerType {
             didUpdateStateSubject.onNext(bleState)
         }
 
-        @objc func centralManager(_ central: CBCentralManager, willRestoreState dict: [String : Any]) {
+        @objc func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
             willRestoreStateSubject.onNext(dict)
         }
 
@@ -160,9 +160,7 @@ class RxCBCentralManager: RxCentralManagerType {
      - returns: Observable wich emits connected peripherals.
      */
     func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBUUID]) -> Observable<[RxPeripheralType]> {
-        return .just(centralManager.retrieveConnectedPeripherals(withServices: serviceUUIDs).map {
-            RxCBPeripheral(peripheral: $0)
-        })
+        return .just(centralManager.retrieveConnectedPeripherals(withServices: serviceUUIDs).map(RxCBPeripheral.init))
     }
 
     /**
@@ -172,8 +170,6 @@ class RxCBCentralManager: RxCentralManagerType {
      - returns: Observable which emits peripherals with specified identifiers.
      */
     func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> Observable<[RxPeripheralType]> {
-        return .just(centralManager.retrievePeripherals(withIdentifiers: identifiers).map {
-            RxCBPeripheral(peripheral: $0)
-        })
+        return .just(centralManager.retrievePeripherals(withIdentifiers: identifiers).map(RxCBPeripheral.init))
     }
 }

--- a/Source/RxCBCharacteristic.swift
+++ b/Source/RxCBCharacteristic.swift
@@ -45,7 +45,7 @@ class RxCBCharacteristic: RxCharacteristicType {
         return characteristic.properties
     }
     var descriptors: [RxDescriptorType]? {
-        return characteristic.descriptors?.map { RxCBDescriptor(descriptor: $0) }
+        return characteristic.descriptors?.map(RxCBDescriptor.init)
     }
     var service: RxServiceType {
         return RxCBService(service: characteristic.service)

--- a/Source/RxCBPeripheral.swift
+++ b/Source/RxCBPeripheral.swift
@@ -59,7 +59,7 @@ class RxCBPeripheral: RxPeripheralType {
 
     /// Peripheral's services
     var services: [RxServiceType]? {
-        return peripheral.services?.map { RxCBService(service: $0) }
+        return peripheral.services?.map(RxCBService.init)
     }
 
     /// Observable which emits peripheral's name changes
@@ -257,9 +257,7 @@ class RxCBPeripheral: RxPeripheralType {
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral, didModifyServices invalidatedServices: [CBService]) {
-            peripheralDidModifyServicesSubject.onNext(invalidatedServices.map {
-                RxCBService(service: $0)
-            })
+            peripheralDidModifyServicesSubject.onNext(invalidatedServices.map(RxCBService.init))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral, didReadRSSI rssi: NSNumber, error: Error?) {
@@ -267,9 +265,7 @@ class RxCBPeripheral: RxPeripheralType {
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-            peripheralDidDiscoverServicesSubject.onNext((peripheral.services?.map {
-                RxCBService(service: $0)
-                }, error))
+            peripheralDidDiscoverServicesSubject.onNext((peripheral.services?.map(RxCBService.init), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,

--- a/Source/RxCBPeripheral.swift
+++ b/Source/RxCBPeripheral.swift
@@ -173,8 +173,8 @@ class RxCBPeripheral: RxPeripheralType {
      - parameter type: Type of write operation
      */
     func writeValue(_ data: Data,
-        for characteristic: RxCharacteristicType,
-        type: CBCharacteristicWriteType) {
+                    for characteristic: RxCharacteristicType,
+                    type: CBCharacteristicWriteType) {
             peripheral.writeValue(data, for: (characteristic as! RxCBCharacteristic).characteristic,
                 type: type)
     }
@@ -273,54 +273,54 @@ class RxCBPeripheral: RxPeripheralType {
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
-            didDiscoverIncludedServicesFor service: CBService,
-            error: Error?) {
+                              didDiscoverIncludedServicesFor service: CBService,
+                              error: Error?) {
                 peripheralDidDiscoverIncludedServicesForServiceSubject.onNext((RxCBService(service: service), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
-            didDiscoverCharacteristicsFor service: CBService,
-            error: Error?) {
+                              didDiscoverCharacteristicsFor service: CBService,
+                              error: Error?) {
                 peripheralDidDiscoverCharacteristicsForServiceSubject.onNext((RxCBService(service: service), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
-            didUpdateValueFor characteristic: CBCharacteristic,
-            error: Error?) {
+                              didUpdateValueFor characteristic: CBCharacteristic,
+                              error: Error?) {
                 peripheralDidUpdateValueForCharacteristicSubject
                     .onNext((RxCBCharacteristic(characteristic: characteristic), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
-            didWriteValueFor characteristic: CBCharacteristic,
-            error: Error?) {
+                              didWriteValueFor characteristic: CBCharacteristic,
+                              error: Error?) {
                 peripheralDidWriteValueForCharacteristicSubject
                     .onNext((RxCBCharacteristic(characteristic: characteristic), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
-            didUpdateNotificationStateFor characteristic: CBCharacteristic,
-            error: Error?) {
+                              didUpdateNotificationStateFor characteristic: CBCharacteristic,
+                              error: Error?) {
                 peripheralDidUpdateNotificationStateForCharacteristicSubject
                     .onNext((RxCBCharacteristic(characteristic: characteristic), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
-            didDiscoverDescriptorsFor characteristic: CBCharacteristic,
-            error: Error?) {
+                              didDiscoverDescriptorsFor characteristic: CBCharacteristic,
+                              error: Error?) {
                 peripheralDidDiscoverDescriptorsForCharacteristicSubject
                     .onNext((RxCBCharacteristic(characteristic: characteristic), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
-            didUpdateValueFor descriptor: CBDescriptor,
-            error: Error?) {
+                              didUpdateValueFor descriptor: CBDescriptor,
+                              error: Error?) {
                 peripheralDidUpdateValueForDescriptorSubject.onNext((RxCBDescriptor(descriptor: descriptor), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
-            didWriteValueFor descriptor: CBDescriptor,
-            error: Error?) {
+                              didWriteValueFor descriptor: CBDescriptor,
+                              error: Error?) {
                 peripheralDidWriteValueForDescriptorSubject.onNext((RxCBDescriptor(descriptor: descriptor), error))
         }
     }

--- a/Source/RxCBService.swift
+++ b/Source/RxCBService.swift
@@ -35,10 +35,10 @@ class RxCBService: RxServiceType {
         return service.uuid
     }
     var characteristics: [RxCharacteristicType]? {
-        return service.characteristics?.map { RxCBCharacteristic(characteristic: $0) }
+        return service.characteristics?.map(RxCBCharacteristic.init)
     }
     var includedServices: [RxServiceType]? {
-        return service.includedServices?.map { RxCBService(service: $0) }
+        return service.includedServices?.map(RxCBService.init)
     }
     var isPrimary: Bool {
         return service.isPrimary

--- a/Source/RxCentralManagerType.swift
+++ b/Source/RxCentralManagerType.swift
@@ -32,9 +32,9 @@ protocol RxCentralManagerType {
     /// Observable which emits state changes of central manager after subscriptions
     var rx_didUpdateState: Observable<BluetoothState> { get }
     /// Observable which emits elements after subsciption when central manager want to restore its state
-    var rx_willRestoreState: Observable<[String:Any]> { get }
+    var rx_willRestoreState: Observable<[String: Any]> { get }
     /// Observable which emits peripherals which were discovered after subscription
-    var rx_didDiscoverPeripheral: Observable<(RxPeripheralType, [String:Any], NSNumber)> { get }
+    var rx_didDiscoverPeripheral: Observable<(RxPeripheralType, [String: Any], NSNumber)> { get }
     /// Observable which emits peripherals which were connected after subscription
     var rx_didConnectPeripheral: Observable<RxPeripheralType> { get }
     /// Observable which emits peripherals which failed to connect after subscriptions
@@ -53,7 +53,7 @@ protocol RxCentralManagerType {
                                available peripherals will be discovered.
      - parameter options: Central Manager specific options for scanning
      */
-    func scanForPeripherals(withServices serviceUUIDs: [CBUUID]?, options: [String:Any]?)
+    func scanForPeripherals(withServices serviceUUIDs: [CBUUID]?, options: [String: Any]?)
 
     /**
      Connect to specified peripheral. If connection is successful peripheral will be emitted in rx_didConnectPeripheral
@@ -62,7 +62,7 @@ protocol RxCentralManagerType {
      - parameter peripheral: Peripheral to connect to.
      - parameter options: Central Manager specific connection options.
      */
-    func connect(_ peripheral: RxPeripheralType, options: [String:Any]?)
+    func connect(_ peripheral: RxPeripheralType, options: [String: Any]?)
 
     /**
      Cancel peripheral connection. If successful observable rx_didDisconnectPeripheral will emit disconnected

--- a/Source/RxCharacteristicType.swift
+++ b/Source/RxCharacteristicType.swift
@@ -67,9 +67,5 @@ func == (lhs: RxCharacteristicType, rhs: RxCharacteristicType) -> Bool {
  - returns: True if both arrays contain same characteristics
  */
 func == (lhs: [RxCharacteristicType], rhs: [RxCharacteristicType]) -> Bool {
-    guard lhs.count == rhs.count else {
-        return false
-    }
-
-    return lhs.starts(with: rhs, by: ==)
+    return lhs.count == rhs.count && lhs.starts(with: rhs, by: ==)
 }

--- a/Source/RxServiceType.swift
+++ b/Source/RxServiceType.swift
@@ -63,9 +63,5 @@ func == (lhs: RxServiceType, rhs: RxServiceType) -> Bool {
  - returns: True if both arrays contain same services
  */
 func == (lhs: [RxServiceType], rhs: [RxServiceType]) -> Bool {
-    guard lhs.count == rhs.count else {
-        return false
-    }
-
-    return lhs.starts(with: rhs, by: ==)
+    return lhs.count == rhs.count && lhs.starts(with: rhs, by: ==)
 }

--- a/Source/Service.swift
+++ b/Source/Service.swift
@@ -49,14 +49,14 @@ public class Service {
     public var includedServices: [Service]? {
         return service.includedServices?.map {
             Service(peripheral: peripheral, service: $0)
-        } ?? nil
+        }
     }
 
     /// Service's characteristics
     public var characteristics: [Characteristic]? {
         return service.characteristics?.map {
             Characteristic(characteristic: $0, service: self)
-        } ?? nil
+        }
     }
 
     init(peripheral: Peripheral, service: RxServiceType) {


### PR DESCRIPTION
- Updated RxSwift to 3.2 
- Fixed the swiftlint "vertical alignment" warnings (not sure if this is the preferred formatting?)
- Replaced some flatMap's with map where it made sense (mostly thrown errors)

I also looked through the code and changed some formatting like:
- spacing before/after `:` (e.g `[SomeClass: SomeOtherClass]`)
- remove `else` where it is not needed (because the `if`-part returns)
- replace `if let` with `guard` where it made sense
- replace `map{ SomeClass(something: $0) }` with `map(SomeClass.init)`