### PR TITLE
Fix: reading values when multiple services/characteristics used with same UUID (without breaking existing API)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules: # rule identifiers to exclude from running
   - file_length
   - weak_delegate
   - type_name
+  - large_tuple
 opt_in_rules: # some rules are only opt-in
   - empty_count
   # - missing_docs # Broken in swiftlint 0.12.0 with XCode 8

--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -93,6 +93,8 @@
 		A10F29A51CDCD75900593284 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10F29991CDCD73A00593284 /* Quick.framework */; };
 		A10F29AD1CDCD98400593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5A1CCE65CD005E81CE /* RxSwift.framework */; };
 		A10F29B01CDCD99900593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5E1CCE65EE005E81CE /* RxSwift.framework */; };
+		FA947A3B1EB1C41C000ED0B1 /* UUIDIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */; };
+		FA947A3C1EB1C42F000ED0B1 /* UUIDIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -188,6 +190,7 @@
 		A1299C221CBE3DEE005DEA5B /* ScanOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanOperation.swift; sourceTree = "<group>"; };
 		A1299C231CBE3DEE005DEA5B /* Service.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		A1299C241CBE3DEE005DEA5B /* Unimplemented.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Unimplemented.swift; sourceTree = "<group>"; };
+		FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UUIDIdentifiable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -254,6 +257,7 @@
 				A1299C131CBE3DEE005DEA5B /* Observable+Absorb.swift */,
 				A1299C0F1CBE3DEE005DEA5B /* Boxes.swift */,
 				A1299C0D1CBE3DEE005DEA5B /* BluetoothError.swift */,
+				FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */,
 			);
 			name = Shared;
 			sourceTree = "<group>";
@@ -666,6 +670,7 @@
 				2666FE391CCE4732005E81CE /* RxServiceType.swift in Sources */,
 				2666FE3A1CCE4732005E81CE /* Service.swift in Sources */,
 				2666FE451CCE4732005E81CE /* BluetoothError.swift in Sources */,
+				FA947A3B1EB1C41C000ED0B1 /* UUIDIdentifiable.swift in Sources */,
 				2666FE3E1CCE4732005E81CE /* Characteristic.swift in Sources */,
 				2666FE481CCE4732005E81CE /* RxCBCentralManager.swift in Sources */,
 				2666FE321CCE4732005E81CE /* Descriptor.swift in Sources */,
@@ -706,6 +711,7 @@
 				2666FE2C1CCE4731005E81CE /* RxCentralManagerType.swift in Sources */,
 				2666FE151CCE4731005E81CE /* RxDescriptorType.swift in Sources */,
 				2666FE2B1CCE4731005E81CE /* ScanOperation.swift in Sources */,
+				FA947A3C1EB1C42F000ED0B1 /* UUIDIdentifiable.swift in Sources */,
 				2666FE221CCE4731005E81CE /* RxCBCharacteristic.swift in Sources */,
 				2666FE211CCE4731005E81CE /* RxCharacteristicType.swift in Sources */,
 				2666FE1A1CCE4731005E81CE /* Peripheral.swift in Sources */,

--- a/Source/Boxes.swift
+++ b/Source/Boxes.swift
@@ -32,6 +32,6 @@ class WeakBox<T: AnyObject> : CustomDebugStringConvertible {
 
 extension WeakBox {
     var debugDescription: String {
-        return "WeakBox(\(self.value))"
+        return "WeakBox(\(String(describing: self.value)))"
     }
 }

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -375,11 +375,16 @@ public class Peripheral {
     // MARK: Descriptors
     /**
      Function that triggers descriptors discovery for characteristic
+     If all of the descriptors are already discovered - these are returned without doing any underlying Bluetooth operations.
      - Parameter characteristic: `Characteristic` instance for which descriptors should be discovered.
      - Returns: Observable that emits `Next` with array of `Descriptor` instances, once they're discovered.
      Immediately after that `.Complete` is emitted.
      */
     public func discoverDescriptors(for characteristic: Characteristic) -> Observable<[Descriptor]> {
+        if let descriptors = characteristic.descriptors {
+            let resultDescriptors = descriptors.map { Descriptor(descriptor: $0.descriptor, characteristic: characteristic) }
+            return ensureValidPeripheralState(for: .just(resultDescriptors))
+        }
         let observable = peripheral
             .rx_didDiscoverDescriptorsForCharacteristic
             .filter { $0.0 == characteristic.characteristic }

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -123,19 +123,17 @@ public class Peripheral {
      Immediately after that `.Complete` is emitted.
      */
     public func discoverServices(_ serviceUUIDs: [CBUUID]?) -> Observable<[Service]> {
-        if let identifiers = serviceUUIDs, let services = self.services?.filter({ identifiers.contains($0.uuid) }), identifiers.count == services.count {
-            return ensureValidPeripheralState(for: .just(services))
+        if let identifiers = serviceUUIDs, !identifiers.isEmpty,
+           let cachedServices = self.services,
+           let filteredServices = filterUUIDItems(uuids: serviceUUIDs, items: cachedServices) {
+           return ensureValidPeripheralState(for: .just(filteredServices))
         }
         let observable = peripheral.rx_didDiscoverServices
         .flatMap { (_, error) -> Observable<[Service]> in
             guard let cachedServices = self.services, error == nil else {
                 throw BluetoothError.servicesDiscoveryFailed(self, error)
             }
-            guard let identifiers = serviceUUIDs else { return .just(cachedServices) }
-            let uuids = cachedServices.map { $0.service.uuid }
-            if Set(identifiers).isSubset(of: Set(uuids)) {
-                let filteredServices = cachedServices
-                    .filter { identifiers.contains($0.uuid)}
+            if let filteredServices = filterUUIDItems(uuids: serviceUUIDs, items: cachedServices) {
                 return .just(filteredServices)
             }
             return .empty()
@@ -163,10 +161,10 @@ public class Peripheral {
      Immediately after that `.Complete` is emitted.
      */
     public func discoverIncludedServices(_ includedServiceUUIDs: [CBUUID]?, for service: Service) -> Observable<[Service]> {
-        if let identifiers = includedServiceUUIDs,
-            let services = service.includedServices?.filter({ identifiers.contains($0.uuid) }),
-            identifiers.count == services.count {
-            return ensureValidPeripheralState(for: .just(services))
+        if let identifiers = includedServiceUUIDs, !identifiers.isEmpty,
+            let services = service.includedServices,
+            let filteredServices = filterUUIDItems(uuids: includedServiceUUIDs, items: services) {
+            return ensureValidPeripheralState(for: .just(filteredServices))
         }
         let observable = peripheral
             .rx_didDiscoverIncludedServicesForService
@@ -176,9 +174,9 @@ public class Peripheral {
                     throw BluetoothError.includedServicesDiscoveryFailed(self, error)
                 }
                 let includedServices = includedRxServices.map { Service(peripheral: self, service: $0) }
-                guard let includedServiceUUIDs = includedServiceUUIDs else { return .just(includedServices) }
-                let filteredServices = includedServices.filter { includedServiceUUIDs.contains($0.uuid) }
-                if filteredServices.count == includedServiceUUIDs.count { return .just(filteredServices) }
+                if let filteredServices = filterUUIDItems(uuids: includedServiceUUIDs, items: includedServices) {
+                    return .just(filteredServices)
+                }
                 return .empty()
             }
             .take(1)
@@ -203,9 +201,10 @@ public class Peripheral {
      Immediately after that `.Complete` is emitted.
      */
     public func discoverCharacteristics(_ characteristicUUIDs: [CBUUID]?, for service: Service) -> Observable<[Characteristic]> {
-        if let identifiers = characteristicUUIDs, let characteristics = service.characteristics?.filter({ identifiers.contains($0.uuid) }),
-            identifiers.count == characteristics.count {
-            return ensureValidPeripheralState(for: .just(characteristics))
+        if let identifiers = characteristicUUIDs, !identifiers.isEmpty,
+            let characteristics = service.characteristics,
+            let filteredCharacteristics = filterUUIDItems(uuids: characteristicUUIDs, items: characteristics) {
+            return ensureValidPeripheralState(for: .just(filteredCharacteristics))
         }
         let observable = peripheral
             .rx_didDiscoverCharacteristicsForService
@@ -215,9 +214,9 @@ public class Peripheral {
                     throw BluetoothError.characteristicsDiscoveryFailed(service, error)
                 }
                 let characteristics = rxCharacteristics.map { Characteristic(characteristic: $0, service: service) }
-                guard let characteristicIdentifiers = characteristicUUIDs else { return .just(characteristics) }
-                let filteredCharacteristics = characteristics.filter { characteristicIdentifiers.contains($0.uuid) }
-                if filteredCharacteristics.count == characteristicIdentifiers.count { return .just(filteredCharacteristics) }
+                if let filteredCharacteristics = filterUUIDItems(uuids: characteristicUUIDs, items: characteristics) {
+                    return .just(filteredCharacteristics)
+                }
                 return .empty()
             }
             .take(1)

--- a/Source/RxCBCentralManager.swift
+++ b/Source/RxCBCentralManager.swift
@@ -84,27 +84,27 @@ class RxCBCentralManager: RxCentralManagerType {
         }
     }
 
-    /// Observable which infroms when central manager did change its state
+    /// Observable which informs when central manager did change its state
     var rx_didUpdateState: Observable<BluetoothState> {
         return internalDelegate.didUpdateStateSubject
     }
-    /// Observable which infroms when central manager is about to restore its state
+    /// Observable which informs when central manager is about to restore its state
     var rx_willRestoreState: Observable<[String: Any]> {
         return internalDelegate.willRestoreStateSubject
     }
-    /// Observable which infroms when central manage discovered peripheral
+    /// Observable which informs when central manage discovered peripheral
     var rx_didDiscoverPeripheral: Observable<(RxPeripheralType, [String: Any], NSNumber)> {
         return internalDelegate.didDiscoverPeripheralSubject
     }
-    /// Observable which infroms when central manager connected to peripheral
+    /// Observable which informs when central manager connected to peripheral
     var rx_didConnectPeripheral: Observable<RxPeripheralType> {
         return internalDelegate.didConnectPerihperalSubject
     }
-    /// Observable which infroms when central manager failed to connect to peripheral
+    /// Observable which informs when central manager failed to connect to peripheral
     var rx_didFailToConnectPeripheral: Observable<(RxPeripheralType, Error?)> {
         return internalDelegate.didFailToConnectPeripheralSubject
     }
-    /// Observable which infroms when central manager disconnected from peripheral
+    /// Observable which informs when central manager disconnected from peripheral
     var rx_didDisconnectPeripheral: Observable<(RxPeripheralType, Error?)> {
         return internalDelegate.didDisconnectPeripheral
     }

--- a/Source/RxCBCharacteristic.swift
+++ b/Source/RxCBCharacteristic.swift
@@ -51,4 +51,8 @@ class RxCBCharacteristic: RxCharacteristicType {
         return RxCBService(service: characteristic.service)
     }
 
+    func isEqualTo(characteristic: RxCharacteristicType) -> Bool {
+        guard let rhs = characteristic as? RxCBCharacteristic else { return false }
+        return self.characteristic === rhs.characteristic
+    }
 }

--- a/Source/RxCBDescriptor.swift
+++ b/Source/RxCBDescriptor.swift
@@ -40,4 +40,9 @@ class RxCBDescriptor: RxDescriptorType {
     var value: Any? {
         return descriptor.value
     }
+
+    func isEqualTo(descriptor: RxDescriptorType) -> Bool {
+        guard let rhs = descriptor as? RxCBDescriptor else { return false }
+        return self.descriptor === rhs.descriptor
+    }
 }

--- a/Source/RxCBService.swift
+++ b/Source/RxCBService.swift
@@ -43,4 +43,9 @@ class RxCBService: RxServiceType {
     var isPrimary: Bool {
         return service.isPrimary
     }
+
+    func isEqualTo(service: RxServiceType) -> Bool {
+        guard let rhs = service as? RxCBService else { return false }
+        return self.service === rhs.service
+    }
 }

--- a/Source/RxCharacteristicType.swift
+++ b/Source/RxCharacteristicType.swift
@@ -45,7 +45,12 @@ protocol RxCharacteristicType {
 
     /// Characteristic service
     var service: RxServiceType { get }
+
+    /// True if the two characteristic objects considered equal
+    func isEqualTo(characteristic: RxCharacteristicType) -> Bool
 }
+
+extension Equatable where Self: RxCharacteristicType {}
 
 /**
  Characteristics are equal if their UUIDs are equal
@@ -55,7 +60,7 @@ protocol RxCharacteristicType {
  - returns: True if characteristics are the same
  */
 func == (lhs: RxCharacteristicType, rhs: RxCharacteristicType) -> Bool {
-    return lhs.uuid == rhs.uuid
+    return lhs.isEqualTo(characteristic: rhs)
 }
 
 /**

--- a/Source/RxServiceType.swift
+++ b/Source/RxServiceType.swift
@@ -39,6 +39,10 @@ protocol RxServiceType {
 
     /// True if service is a primary service
     var isPrimary: Bool { get }
+
+    /// True if the two service objects considered equal
+    func isEqualTo(service: RxServiceType) -> Bool
+
 }
 
 extension Equatable where Self: RxServiceType {}
@@ -51,7 +55,7 @@ extension Equatable where Self: RxServiceType {}
  - returns: True if services UUIDs are the same.
  */
 func == (lhs: RxServiceType, rhs: RxServiceType) -> Bool {
-    return lhs.uuid == rhs.uuid
+    return lhs.isEqualTo(service: rhs)
 }
 
 /**

--- a/Source/UUIDIdentifiable.swift
+++ b/Source/UUIDIdentifiable.swift
@@ -23,26 +23,27 @@
 import Foundation
 import CoreBluetooth
 
-/**
- Protocol which wraps characteristic's descriptor for bluetooth devices.
- */
-protocol RxDescriptorType {
-
-    /// Descriptor UUID
+protocol UUIDIdentifiable {
     var uuid: CBUUID { get }
-
-    /// Descriptor's characteristic
-    var characteristic: RxCharacteristicType { get }
-
-    /// Descriptor's value
-    var value: Any? { get }
-
-    /// True if the two descriptor objects considered equal
-    func isEqualTo(descriptor: RxDescriptorType) -> Bool
 }
 
-extension Equatable where Self: RxDescriptorType {}
+extension Characteristic: UUIDIdentifiable { }
+extension Service: UUIDIdentifiable { }
 
-func == (lhs: RxDescriptorType, rhs: RxDescriptorType) -> Bool {
-    return lhs.isEqualTo(descriptor: rhs)
+/**
+ Filters an item list based on the provided UUID list. The items must conform to UUIDIdentifiable.
+ Only items returned whose UUID matches an item in the provided UUID list.
+ Each UUID should have at least one item matching in the items list. Otherwise the result is nil.
+
+ - uuids: a UUID list or nil
+ - items: items to be filtered
+ - Returns: the filtered item list
+ */
+func filterUUIDItems<T: UUIDIdentifiable>(uuids: [CBUUID]?, items: [T]) -> [T]? {
+    guard let uuids = uuids, !uuids.isEmpty else { return items }
+
+    let itemsUUIDs = items.map { $0.uuid }
+    let uuidsSet = Set(uuids)
+    guard uuidsSet.isSubset(of: Set(itemsUUIDs)) else { return nil }
+    return items.filter { uuidsSet.contains($0.uuid) }
 }

--- a/Tests/FakeCharacteristic.swift
+++ b/Tests/FakeCharacteristic.swift
@@ -40,4 +40,8 @@ class FakeCharacteristic: RxCharacteristicType {
         self.service = service
     }
 
+    func isEqualTo(characteristic: RxCharacteristicType) -> Bool {
+        return uuid == characteristic.uuid
+    }
+
 }

--- a/Tests/FakeDescriptor.swift
+++ b/Tests/FakeDescriptor.swift
@@ -33,4 +33,8 @@ class FakeDescriptor: RxDescriptorType {
     init(characteristic: RxCharacteristicType) {
         self.characteristic = characteristic
     }
+
+    func isEqualTo(descriptor: RxDescriptorType) -> Bool {
+        return uuid == descriptor.uuid
+    }
 }

--- a/Tests/FakeService.swift
+++ b/Tests/FakeService.swift
@@ -32,4 +32,9 @@ class FakeService: RxServiceType {
     var characteristics: [RxCharacteristicType]? = nil
     var includedServices: [RxServiceType]? = nil
     var isPrimary: Bool = false
+
+    func isEqualTo(service: RxServiceType) -> Bool {
+        return uuid == service.uuid
+    }
+
 }


### PR DESCRIPTION
(See issues: #81 and #82)

Earlier when discovering services/characteristics UUID comparison was used to
determine for a given service/characteristics if CBPeripheralDelegate callback
was related to a given service/characteristic instance.
It worked only when each service/characteristic had unique UUID.
This approach failed to work when multiple service/characteristic instances used same UUID.
The other issue was that service/characteristics discovery assumed that the result list count
will be the same as the request UUID list count. In practice the result list can be bigger than
the request UUID list because of the possibility of redundant UUIDs.

The commit fixes both issues above:

- rebased on top of latest master branch

- Refactored RxServiceType, RxCharacteristicType, RxDescriptorType equality.
Service/Characteristic/Descriptor instances will be considered equal if the the wrapped
CoreBluetooth objects references are equal. This guarantees proper bindings with
CBPeripheralDelegate callbacks with corresponding CoreBluetooth objects.

- Result list count of service/characteristics discoveries filtered based on the original request UUID list

- Some code in unit tests is updated to make sure unit tests are passing

- added a filter logic that is used to check cached items for discoverServices/discoverIncludedServices/discoverCharacteristics calls. All the unit tests are passing. The template function is filterCachedItems.

- Added caching for discovered descriptors

- Fixed Xcode 8.3.2 warning(s)

- Additional minor fixes

BTW: we are testing this with real HW and it works.