### PR TITLE
Added unique identifier(memory address) to Peripheral.

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v5.1.1"
 github "Quick/Quick" "v0.10.0"
-github "ReactiveX/RxSwift" "3.2.0"
+github "ReactiveX/RxSwift" "3.4.1"

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -86,7 +86,7 @@ public class Peripheral {
      Unique identifier of `Peripheral` object instance. Should be removed in 4.0
      */
     @available(*, deprecated)
-    public var objectId: Int {
+    public var objectId: UInt {
         return peripheral.objectId
     }
 

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -83,6 +83,13 @@ public class Peripheral {
     }
 
     /**
+     Unique identifier of `Peripheral` object instance. Should be removed in 4.0
+     */
+    public var objectId: Int {
+        return peripheral.objectId
+    }
+
+    /**
      A list of services that have been discovered. Analogous to   [`services`](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBPeripheral_Class/#//apple_ref/occ/instp/CBPeripheral/services) of `CBPeripheral`.
      */
     public var services: [Service]? {

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -85,6 +85,7 @@ public class Peripheral {
     /**
      Unique identifier of `Peripheral` object instance. Should be removed in 4.0
      */
+    @available(*, deprecated)
     public var objectId: Int {
         return peripheral.objectId
     }

--- a/Source/RxCBPeripheral.swift
+++ b/Source/RxCBPeripheral.swift
@@ -49,7 +49,7 @@ class RxCBPeripheral: RxPeripheralType {
 
     @available(*, deprecated)
     var objectId: Int {
-        return Int(ObjectIdentifier(peripheral))
+        return Int(bitPattern: ObjectIdentifier(peripheral))
     }
 
     /// Peripheral's name

--- a/Source/RxCBPeripheral.swift
+++ b/Source/RxCBPeripheral.swift
@@ -47,8 +47,9 @@ class RxCBPeripheral: RxPeripheralType {
         return peripheral.identifier
     }
 
+    @available(*, deprecated)
     var objectId: Int {
-        unsafeBitCast(peripheral, to: Int.self)
+        return Int(ObjectIdentifier(peripheral))
     }
 
     /// Peripheral's name

--- a/Source/RxCBPeripheral.swift
+++ b/Source/RxCBPeripheral.swift
@@ -48,8 +48,8 @@ class RxCBPeripheral: RxPeripheralType {
     }
 
     @available(*, deprecated)
-    var objectId: Int {
-        return Int(bitPattern: ObjectIdentifier(peripheral))
+    var objectId: UInt {
+        return UInt(bitPattern: ObjectIdentifier(peripheral))
     }
 
     /// Peripheral's name

--- a/Source/RxCBPeripheral.swift
+++ b/Source/RxCBPeripheral.swift
@@ -47,6 +47,10 @@ class RxCBPeripheral: RxPeripheralType {
         return peripheral.identifier
     }
 
+    var objectId: Int {
+        unsafeBitCast(peripheral, to: Int.self)
+    }
+
     /// Peripheral's name
     var name: String? {
         return peripheral.name

--- a/Source/RxPeripheralType.swift
+++ b/Source/RxPeripheralType.swift
@@ -35,6 +35,9 @@ protocol RxPeripheralType {
     /// Peripheral's identifier
     var identifier: UUID { get }
 
+    /// Unique identifier of object. Should be removed in 4.0
+    var objectId: Int { get }
+
     /// Peripheral's state
     var state: CBPeripheralState { get }
 

--- a/Source/RxPeripheralType.swift
+++ b/Source/RxPeripheralType.swift
@@ -36,6 +36,7 @@ protocol RxPeripheralType {
     var identifier: UUID { get }
 
     /// Unique identifier of object. Should be removed in 4.0
+    @available(*, deprecated)
     var objectId: Int { get }
 
     /// Peripheral's state

--- a/Source/RxPeripheralType.swift
+++ b/Source/RxPeripheralType.swift
@@ -37,7 +37,7 @@ protocol RxPeripheralType {
 
     /// Unique identifier of object. Should be removed in 4.0
     @available(*, deprecated)
-    var objectId: Int { get }
+    var objectId: UInt { get }
 
     /// Peripheral's state
     var state: CBPeripheralState { get }

--- a/Tests/FakePeripheral.swift
+++ b/Tests/FakePeripheral.swift
@@ -35,6 +35,7 @@ class FakePeripheral: RxPeripheralType {
     var rx_state: Observable<CBPeripheralState> = .never()
     var services: [RxServiceType]? = nil
     var identifier: UUID = UUID()
+    var objectId = 0
     var maximumWriteValueLength = 0
 
     var RSSI: Int? = nil


### PR DESCRIPTION
Adds unique identifier to `Peripheral` instance, which allows react-native-ble library to implement couple of features. It's temporary thing and should not be necessary in next version of the library.