### PR TITLE
Add objectId property to the BLE objects.

### DIFF
--- a/Source/Characteristic.swift
+++ b/Source/Characteristic.swift
@@ -44,6 +44,14 @@ public class Characteristic {
         return characteristic.value
     }
 
+    /** 
+    Unique identifier of an object. Should be removed in 4.0
+    */
+    @available(*, deprecated)
+    var objectId: UInt {
+        return characteristic.objectId
+    }
+
     /**
      The Bluetooth UUID of the `Characteristic` instance.
      */

--- a/Source/Descriptor.swift
+++ b/Source/Descriptor.swift
@@ -41,6 +41,14 @@ public class Descriptor {
     public let characteristic: Characteristic
 
     /**
+    Unique identifier of an object. Should be removed in 4.0
+     */
+    @available(*, deprecated)
+    var objectId: UInt {
+        return descriptor.objectId
+    }
+
+    /**
      The Bluetooth UUID of the `Descriptor` instance.
      */
     public var uuid: CBUUID {

--- a/Source/RxCBCharacteristic.swift
+++ b/Source/RxCBCharacteristic.swift
@@ -32,6 +32,10 @@ class RxCBCharacteristic: RxCharacteristicType {
         self.characteristic = characteristic
     }
 
+    @available(*, deprecated)
+    var objectId: UInt {
+        return UInt(bitPattern: ObjectIdentifier(characteristic))
+    }
     var uuid: CBUUID {
         return characteristic.uuid
     }

--- a/Source/RxCBDescriptor.swift
+++ b/Source/RxCBDescriptor.swift
@@ -31,6 +31,10 @@ class RxCBDescriptor: RxDescriptorType {
         self.descriptor = descriptor
     }
 
+    @available(*, deprecated)
+    var objectId: UInt {
+        return UInt(bitPattern: ObjectIdentifier(descriptor))
+    }
     var uuid: CBUUID {
         return descriptor.uuid
     }

--- a/Source/RxCBService.swift
+++ b/Source/RxCBService.swift
@@ -31,6 +31,11 @@ class RxCBService: RxServiceType {
         self.service = service
     }
 
+    @available(*, deprecated)
+    var objectId: UInt {
+        return UInt(bitPattern: ObjectIdentifier(service))
+    }
+
     var uuid: CBUUID {
         return service.uuid
     }

--- a/Source/RxCharacteristicType.swift
+++ b/Source/RxCharacteristicType.swift
@@ -28,6 +28,10 @@ import CoreBluetooth
  */
 protocol RxCharacteristicType {
 
+    /// Unique identifier of an object. Should be removed in 4.0
+    @available(*, deprecated)
+    var objectId: UInt { get }
+
     /// Characteristic UUID
     var uuid: CBUUID { get }
 

--- a/Source/RxDescriptorType.swift
+++ b/Source/RxDescriptorType.swift
@@ -28,6 +28,10 @@ import CoreBluetooth
  */
 protocol RxDescriptorType {
 
+    /// Unique identifier of an object. Should be removed in 4.0
+    @available(*, deprecated)
+    var objectId: UInt { get }
+
     /// Descriptor UUID
     var uuid: CBUUID { get }
 

--- a/Source/RxServiceType.swift
+++ b/Source/RxServiceType.swift
@@ -28,6 +28,10 @@ import CoreBluetooth
  */
 protocol RxServiceType {
 
+    /// Unique identifier of an object. Should be removed in 4.0
+    @available(*, deprecated)
+    var objectId: UInt { get }
+
     /// Service's UUID
     var uuid: CBUUID { get }
 

--- a/Source/Service.swift
+++ b/Source/Service.swift
@@ -40,6 +40,12 @@ public class Service {
         return service.isPrimary
     }
 
+    /// Unique identifier of an object. Should be removed in 4.0
+    @available(*, deprecated)
+    var objectId: UInt {
+        return service.objectId
+    }
+
     /// Service's UUID
     public var uuid: CBUUID {
         return service.uuid

--- a/Tests/FakeCharacteristic.swift
+++ b/Tests/FakeCharacteristic.swift
@@ -27,6 +27,7 @@ import CoreBluetooth
 
 class FakeCharacteristic: RxCharacteristicType {
 
+    var objectId: UInt = 0
     var uuid: CBUUID = CBUUID(string: "aabb")
     var value: Data? = nil
     var isNotifying: Bool = false

--- a/Tests/FakeDescriptor.swift
+++ b/Tests/FakeDescriptor.swift
@@ -27,6 +27,7 @@ import CoreBluetooth
 
 class FakeDescriptor: RxDescriptorType {
 
+    var objectId: UInt = 0
     var uuid = CBUUID()
     var characteristic: RxCharacteristicType
     var value: Any? = nil

--- a/Tests/FakePeripheral.swift
+++ b/Tests/FakePeripheral.swift
@@ -30,12 +30,12 @@ import RxBluetoothKit
 class FakePeripheral: RxPeripheralType {
 
 
+    var objectId: UInt = 0
     var name: String? = nil
     var state: CBPeripheralState = CBPeripheralState.connected
     var rx_state: Observable<CBPeripheralState> = .never()
     var services: [RxServiceType]? = nil
     var identifier: UUID = UUID()
-    var objectId = 0
     var maximumWriteValueLength = 0
 
     var RSSI: Int? = nil

--- a/Tests/FakeService.swift
+++ b/Tests/FakeService.swift
@@ -27,6 +27,7 @@ import CoreBluetooth
 
 class FakeService: RxServiceType {
 
+    var objectId: UInt = 0
     var uuid: CBUUID = CBUUID(string: "bbaa")
 
     var characteristics: [RxCharacteristicType]? = nil


### PR DESCRIPTION
Add missing `objectId` for other BLE classes.