### PR TITLE
Add option to dynamically enable logging

### DIFF
--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -93,6 +93,8 @@
 		A10F29A51CDCD75900593284 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10F29991CDCD73A00593284 /* Quick.framework */; };
 		A10F29AD1CDCD98400593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5A1CCE65CD005E81CE /* RxSwift.framework */; };
 		A10F29B01CDCD99900593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5E1CCE65EE005E81CE /* RxSwift.framework */; };
+		D74B16851ED417AA006D5996 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74B16841ED417AA006D5996 /* Logging.swift */; };
+		D74B16861ED417AA006D5996 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74B16841ED417AA006D5996 /* Logging.swift */; };
 		FA947A3B1EB1C41C000ED0B1 /* UUIDIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */; };
 		FA947A3C1EB1C42F000ED0B1 /* UUIDIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */; };
 /* End PBXBuildFile section */
@@ -190,6 +192,7 @@
 		A1299C221CBE3DEE005DEA5B /* ScanOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanOperation.swift; sourceTree = "<group>"; };
 		A1299C231CBE3DEE005DEA5B /* Service.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		A1299C241CBE3DEE005DEA5B /* Unimplemented.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Unimplemented.swift; sourceTree = "<group>"; };
+		D74B16841ED417AA006D5996 /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UUIDIdentifiable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -258,6 +261,7 @@
 				A1299C0F1CBE3DEE005DEA5B /* Boxes.swift */,
 				A1299C0D1CBE3DEE005DEA5B /* BluetoothError.swift */,
 				FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */,
+				D74B16841ED417AA006D5996 /* Logging.swift */,
 			);
 			name = Shared;
 			sourceTree = "<group>";
@@ -662,6 +666,7 @@
 				2666FE3D1CCE4732005E81CE /* RxCBCharacteristic.swift in Sources */,
 				2666FE3C1CCE4732005E81CE /* RxCharacteristicType.swift in Sources */,
 				2666FE351CCE4732005E81CE /* Peripheral.swift in Sources */,
+				D74B16851ED417AA006D5996 /* Logging.swift in Sources */,
 				2666FE331CCE4732005E81CE /* RxPeripheralType.swift in Sources */,
 				2666FE441CCE4732005E81CE /* Boxes.swift in Sources */,
 				2666FE311CCE4732005E81CE /* RxCBDescriptor.swift in Sources */,
@@ -706,6 +711,7 @@
 				2666FE241CCE4731005E81CE /* Observable+QueueSubscribeOn.swift in Sources */,
 				2666FE2E1CCE4731005E81CE /* BluetoothManager.swift in Sources */,
 				2666FE251CCE4731005E81CE /* Unimplemented.swift in Sources */,
+				D74B16861ED417AA006D5996 /* Logging.swift in Sources */,
 				2666FE201CCE4731005E81CE /* RxCBService.swift in Sources */,
 				2666FE1C1CCE4731005E81CE /* DeviceIdentifiers.swift in Sources */,
 				2666FE2C1CCE4731005E81CE /* RxCentralManagerType.swift in Sources */,

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -60,6 +60,12 @@ public class BluetoothManager {
     /// Queue of scan operations which are waiting for an execution
     private var scanQueue: [ScanOperation] = []
 
+    /// Unique identifier of an object. Should be removed in 4.0
+    @available(*, deprecated)
+    public var objectId: UInt {
+        return centralManager.objectId
+    }
+
     // MARK: Initialization
 
     /**

--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -52,7 +52,7 @@ public class RxBluetoothKitLog {
     }
 
     fileprivate static func log(with logLevel: LogLevel, message: @autoclosure () -> String) {
-        if currentLogLevel.rawValue >= logLevel.rawValue {
+        if currentLogLevel >= logLevel {
             print(tag(with: logLevel), message())
         }
     }
@@ -75,6 +75,15 @@ public class RxBluetoothKitLog {
 
     static func e(_ message:  @autoclosure () -> String) {
         log(with: .error, message: message)
+    }
+}
+
+extension RxBluetoothKitLog.LogLevel : Comparable {
+    public static func < (lhs: RxBluetoothKitLog.LogLevel, rhs: RxBluetoothKitLog.LogLevel) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
+    public static func == (lhs: RxBluetoothKitLog.LogLevel, rhs: RxBluetoothKitLog.LogLevel) -> Bool {
+        return lhs.rawValue == rhs.rawValue
     }
 }
 

--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -1,0 +1,125 @@
+//
+//  Logging.swift
+//  RxBluetoothKit
+//
+//  Created by Przemysław Lenart on 23/05/17.
+//  Copyright © 2017 Polidea. All rights reserved.
+//
+
+import Foundation
+import CoreBluetooth
+
+public class RxBluetoothKitLog {
+
+    fileprivate static var currentLogLevel: LogLevel = .none
+
+    public enum LogLevel: Int {
+        case none = 0
+        case verbose = 1
+        case debug = 2
+        case info = 3
+        case warning = 4
+        case error = 5
+    }
+
+    public static func setLogLevel(_ logLevel: LogLevel) {
+        currentLogLevel = logLevel
+    }
+
+    fileprivate static func tag(with logLevel: LogLevel) -> String {
+        let prefix: String
+
+        switch logLevel {
+        case .none:
+            prefix = "[RxBLEKit|NONE|"
+        case .verbose:
+            prefix = "[RxBLEKit|VERB|"
+        case .debug:
+            prefix = "[RxBLEKit|DEBG|"
+        case .info:
+            prefix = "[RxBLEKit|INFO|"
+        case .warning:
+            prefix = "[RxBLEKit|WARN|"
+        case .error:
+            prefix = "[RxBLEKit|ERRO|"
+        }
+        let time = Date().timeIntervalSinceReferenceDate
+        return prefix + String(format: "%02.0f:%02.0f:%02.0f.%03.f]:",
+                               floor(time / 3600.0).truncatingRemainder(dividingBy: 24),
+                               floor(time / 60.0).truncatingRemainder(dividingBy: 60),
+                               floor(time).truncatingRemainder(dividingBy: 60),
+                               floor(time * 1000).truncatingRemainder(dividingBy: 1000))
+    }
+
+    fileprivate static func log(with logLevel: LogLevel, message: @autoclosure () -> String) {
+        if currentLogLevel.rawValue >= logLevel.rawValue {
+            print(tag(with: logLevel), message())
+        }
+    }
+
+    static func v(_ message:  @autoclosure () -> String) {
+        log(with: .verbose, message: message)
+    }
+
+    static func d(_ message:  @autoclosure () -> String) {
+        log(with: .debug, message: message)
+    }
+
+    static func i(_ message:  @autoclosure () -> String) {
+        log(with: .info, message: message)
+    }
+
+    static func w(_ message:  @autoclosure () -> String) {
+        log(with: .warning, message: message)
+    }
+
+    static func e(_ message:  @autoclosure () -> String) {
+        log(with: .error, message: message)
+    }
+}
+
+protocol Loggable {
+    var logDescription: String { get }
+}
+
+extension Data : Loggable {
+    var logDescription: String {
+        return self.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+extension CBCentralManager : Loggable {
+    var logDescription: String {
+        return "CentralManager(\(UInt(bitPattern: ObjectIdentifier(self)))"
+    }
+}
+
+extension CBPeripheral : Loggable {
+    var logDescription: String {
+        return "Peripheral(uuid: \(identifier), name: \(name))"
+    }
+}
+
+extension CBCharacteristic : Loggable {
+    var logDescription: String {
+        return "Characteristic(uuid: \(uuid), id: \((UInt(bitPattern: ObjectIdentifier(self))))"
+    }
+}
+
+extension CBService : Loggable {
+    var logDescription: String {
+        return "Service(uuid: \(uuid), id: \((UInt(bitPattern: ObjectIdentifier(self))))"
+    }
+}
+
+extension CBDescriptor : Loggable {
+    var logDescription: String {
+        return "Service(uuid: \(uuid), id: \((UInt(bitPattern: ObjectIdentifier(self))))"
+    }
+}
+
+extension Array where Element: Loggable {
+    var logDescription: String {
+        return "[\(self.map { $0.logDescription }.joined(separator: ", "))]"
+    }
+}

--- a/Source/RxCBCentralManager.swift
+++ b/Source/RxCBCentralManager.swift
@@ -34,6 +34,14 @@ class RxCBCentralManager: RxCentralManagerType {
     private let internalDelegate = InternalDelegate()
 
     /**
+     Unique identifier of an object. Should be removed in 4.0
+     */
+    @available(*, deprecated)
+    var objectId: UInt {
+        return UInt(bitPattern: ObjectIdentifier(centralManager))
+    }
+
+    /**
      Create Core Bluetooth implementation of RxCentralManagerType which is used by BluetoothManager class.
      User can specify on which thread all bluetooth events are collected.
 
@@ -52,11 +60,13 @@ class RxCBCentralManager: RxCentralManagerType {
         let didDisconnectPeripheral = PublishSubject<(RxPeripheralType, Error?)>()
 
         @objc func centralManagerDidUpdateState(_ central: CBCentralManager) {
+            RxBluetoothKitLog.d("\(central.logDescription) didUpdateState(state: \(central.state))")
             guard let bleState = BluetoothState(rawValue: central.state.rawValue) else { return }
             didUpdateStateSubject.onNext(bleState)
         }
 
         @objc func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
+            RxBluetoothKitLog.d("\(central.logDescription) willRestoreState(restoredState: \(dict))")
             willRestoreStateSubject.onNext(dict)
         }
 
@@ -64,23 +74,30 @@ class RxCBCentralManager: RxCentralManagerType {
                                   didDiscover peripheral: CBPeripheral,
                                   advertisementData: [String: Any],
                                   rssi: NSNumber) {
-                didDiscoverPeripheralSubject.onNext((RxCBPeripheral(peripheral: peripheral), advertisementData, rssi))
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(central.logDescription) didDiscover(peripheral: \(peripheral.logDescription), rssi: \(rssi))")
+            didDiscoverPeripheralSubject.onNext((RxCBPeripheral(peripheral: peripheral), advertisementData, rssi))
         }
 
         @objc func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+            RxBluetoothKitLog.d("\(central.logDescription) didConnect(to: \(peripheral.logDescription))")
             didConnectPerihperalSubject.onNext(RxCBPeripheral(peripheral: peripheral))
         }
 
         @objc func centralManager(_ central: CBCentralManager,
                                   didFailToConnect peripheral: CBPeripheral,
                                   error: Error?) {
-                didFailToConnectPeripheralSubject.onNext((RxCBPeripheral(peripheral: peripheral), error))
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(central.logDescription) didFailToConnect(to: \(peripheral.logDescription), error: \(error))")
+            didFailToConnectPeripheralSubject.onNext((RxCBPeripheral(peripheral: peripheral), error))
         }
 
         @objc func centralManager(_ central: CBCentralManager,
                                   didDisconnectPeripheral peripheral: CBPeripheral,
                                   error: Error?) {
-                didDisconnectPeripheral.onNext((RxCBPeripheral(peripheral: peripheral), error))
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(central.logDescription) didDisconnect(from: \(peripheral.logDescription), error: \(error))")
+            didDisconnectPeripheral.onNext((RxCBPeripheral(peripheral: peripheral), error))
         }
     }
 

--- a/Source/RxCBPeripheral.swift
+++ b/Source/RxCBPeripheral.swift
@@ -258,70 +258,92 @@ class RxCBPeripheral: RxPeripheralType {
         let peripheralDidWriteValueForDescriptorSubject = PublishSubject<(RxDescriptorType, Error?)>()
 
         @objc func peripheralDidUpdateName(_ peripheral: CBPeripheral) {
+            RxBluetoothKitLog.d("\(peripheral.logDescription) didUpdateName(name: \(peripheral.name))")
             peripheralDidUpdateNameSubject.onNext(peripheral.name)
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral, didModifyServices invalidatedServices: [CBService]) {
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(peripheral.logDescription) didModifyServices(services: [\(invalidatedServices.logDescription))]")
             peripheralDidModifyServicesSubject.onNext(invalidatedServices.map(RxCBService.init))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral, didReadRSSI rssi: NSNumber, error: Error?) {
+            RxBluetoothKitLog.d("\(peripheral.logDescription) didReadRSSI(rssi: \(rssi), error: \(error))")
             peripheralDidReadRSSISubject.onNext((rssi.intValue, error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(peripheral.logDescription) didDiscoverServices(services: \(peripheral.services?.logDescription), error: \(error))")
             peripheralDidDiscoverServicesSubject.onNext((peripheral.services?.map(RxCBService.init), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
                               didDiscoverIncludedServicesFor service: CBService,
                               error: Error?) {
-                peripheralDidDiscoverIncludedServicesForServiceSubject.onNext((RxCBService(service: service), error))
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(peripheral.logDescription) didDiscoverIncludedServices(for:\(service.logDescription), includedServices: \(service.includedServices?.logDescription), error: \(error))")
+            peripheralDidDiscoverIncludedServicesForServiceSubject.onNext((RxCBService(service: service), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
                               didDiscoverCharacteristicsFor service: CBService,
                               error: Error?) {
-                peripheralDidDiscoverCharacteristicsForServiceSubject.onNext((RxCBService(service: service), error))
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(peripheral.logDescription) didDiscoverCharacteristicsFor(for:\(service.logDescription), characteristics: \(service.characteristics?.logDescription), error: \(error))")
+            peripheralDidDiscoverCharacteristicsForServiceSubject.onNext((RxCBService(service: service), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
                               didUpdateValueFor characteristic: CBCharacteristic,
                               error: Error?) {
-                peripheralDidUpdateValueForCharacteristicSubject
-                    .onNext((RxCBCharacteristic(characteristic: characteristic), error))
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(peripheral.logDescription) didUpdateValueFor(for:\(characteristic.logDescription), value: \(characteristic.value?.logDescription), error: \(error))")
+            peripheralDidUpdateValueForCharacteristicSubject
+                .onNext((RxCBCharacteristic(characteristic: characteristic), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
                               didWriteValueFor characteristic: CBCharacteristic,
                               error: Error?) {
-                peripheralDidWriteValueForCharacteristicSubject
-                    .onNext((RxCBCharacteristic(characteristic: characteristic), error))
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(peripheral.logDescription) didWriteValueFor(for:\(characteristic.logDescription), value: \(characteristic.value?.logDescription), error: \(error))")
+            peripheralDidWriteValueForCharacteristicSubject
+                .onNext((RxCBCharacteristic(characteristic: characteristic), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
                               didUpdateNotificationStateFor characteristic: CBCharacteristic,
                               error: Error?) {
-                peripheralDidUpdateNotificationStateForCharacteristicSubject
-                    .onNext((RxCBCharacteristic(characteristic: characteristic), error))
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(peripheral.logDescription) didUpdateNotificationStateFor(for:\(characteristic.logDescription), isNotifying: \(characteristic.isNotifying), error: \(error))")
+            peripheralDidUpdateNotificationStateForCharacteristicSubject
+                .onNext((RxCBCharacteristic(characteristic: characteristic), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
                               didDiscoverDescriptorsFor characteristic: CBCharacteristic,
                               error: Error?) {
-                peripheralDidDiscoverDescriptorsForCharacteristicSubject
-                    .onNext((RxCBCharacteristic(characteristic: characteristic), error))
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(peripheral.logDescription) didDiscoverDescriptorsFor(for:\(characteristic.logDescription), descriptors: \(characteristic.descriptors?.logDescription), error: \(error))")
+            peripheralDidDiscoverDescriptorsForCharacteristicSubject
+                .onNext((RxCBCharacteristic(characteristic: characteristic), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
                               didUpdateValueFor descriptor: CBDescriptor,
                               error: Error?) {
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(peripheral.logDescription) didUpdateValueFor(for:\(descriptor.logDescription), value: \(descriptor.value), error: \(error))")
                 peripheralDidUpdateValueForDescriptorSubject.onNext((RxCBDescriptor(descriptor: descriptor), error))
         }
 
         @objc func peripheral(_ peripheral: CBPeripheral,
                               didWriteValueFor descriptor: CBDescriptor,
                               error: Error?) {
+            // swiftlint:disable:next line_length TODO: multiline string in Swift 4
+            RxBluetoothKitLog.d("\(peripheral.logDescription) didWriteValueFor(for:\(descriptor.logDescription), error: \(error))")
                 peripheralDidWriteValueForDescriptorSubject.onNext((RxCBDescriptor(descriptor: descriptor), error))
         }
     }

--- a/Source/RxCentralManagerType.swift
+++ b/Source/RxCentralManagerType.swift
@@ -29,6 +29,10 @@ import CoreBluetooth
 */
 protocol RxCentralManagerType {
 
+    /// Unique identifier of an object. Should be removed in 4.0
+    @available(*, deprecated)
+    var objectId: UInt { get }
+
     /// Observable which emits state changes of central manager after subscriptions
     var rx_didUpdateState: Observable<BluetoothState> { get }
     /// Observable which emits elements after subsciption when central manager want to restore its state

--- a/Tests/FakeCentralManager.swift
+++ b/Tests/FakeCentralManager.swift
@@ -30,6 +30,7 @@ import CoreBluetooth
 
 class FakeCentralManager: RxCentralManagerType {
 
+    var objectId: UInt = 0
     var rx_didUpdateState: Observable<BluetoothState> = .never()
     var rx_willRestoreState: Observable<[String:Any]> = .never()
     var rx_didDiscoverPeripheral: Observable<(RxPeripheralType, [String:Any], NSNumber)> = .never()


### PR DESCRIPTION
- Currently only CoreBluetooth delegates are logged as most basic entry points for BLE debugging.
- Log levels where adjusted to RxAndroidBle library for better compatibility.
- `print()` function was used for faster logging.
- `@autoclosure` was used to execute message only when `currentLogLevel >= messageLogLevel`.
- Added missing `objectId` for Central Manager to be able to distinguish logs from multiple managers. 