### PR TITLE
Public access to `CBPeripheral` instance given

### DIFF
--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -66,6 +66,10 @@ public class BluetoothManager {
         return centralManager.objectId
     }
 
+    public var manager: CBCentralManager {
+        return centralManager.centralManager
+    }
+
     // MARK: Initialization
 
     /**

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -31,7 +31,7 @@ import CoreBluetooth
  allowing to talk to peripheral like discovering characteristics, services and all of the read/write calls.
  */
 public class Peripheral {
-    let manager: BluetoothManager
+    public let manager: BluetoothManager
 
     init(manager: BluetoothManager, peripheral: RxPeripheralType) {
         self.manager = manager

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -60,6 +60,13 @@ public class Peripheral {
     }
 
     /**
+     Underlying `CBPeripheral` instance
+     */
+    public var cbPeripheral: CBPeripheral {
+        return peripheral.peripheral
+    }
+
+    /**
      Current state of `Peripheral` instance described by [`CBPeripheralState`](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBPeripheral_Class/#//apple_ref/c/tdef/CBPeripheralState).
 
      - returns: Current state of `Peripheral` as `CBPeripheralState`.

--- a/Source/RxCBCentralManager.swift
+++ b/Source/RxCBCentralManager.swift
@@ -30,7 +30,7 @@ import CoreBluetooth
  */
 class RxCBCentralManager: RxCentralManagerType {
 
-    private let centralManager: CBCentralManager
+    let centralManager: CBCentralManager
     private let internalDelegate = InternalDelegate()
 
     /**

--- a/Source/RxCentralManagerType.swift
+++ b/Source/RxCentralManagerType.swift
@@ -49,6 +49,9 @@ protocol RxCentralManagerType {
     /// Current state of Central Manager
     var state: BluetoothState { get }
 
+    /// Underlying `CBPeripheral` instance
+    var centralManager: CBCentralManager { get }
+
     /**
      Start scanning for peripherals with specified services. Results will be available on rx_didDiscoverPeripheral
      observable.

--- a/Source/RxPeripheralType.swift
+++ b/Source/RxPeripheralType.swift
@@ -39,6 +39,9 @@ protocol RxPeripheralType {
     @available(*, deprecated)
     var objectId: UInt { get }
 
+    /// Underlying `CBPeripheral` instance
+    var peripheral: CBPeripheral { get }
+
     /// Peripheral's state
     var state: CBPeripheralState { get }
 

--- a/Tests/FakeCentralManager.swift
+++ b/Tests/FakeCentralManager.swift
@@ -40,6 +40,10 @@ class FakeCentralManager: RxCentralManagerType {
 
     var state: BluetoothState = BluetoothState.poweredOn
 
+    var centralManager: CBCentralManager {
+        fatalError("Central manager not available")
+    }
+
     var scanForPeripheralsWithServicesTO: TestableObserver<([CBUUID]?, [String:Any]?)>?
     func scanForPeripherals(withServices serviceUUIDs: [CBUUID]?, options: [String:Any]?) {
         scanForPeripheralsWithServicesTO?.onNext((serviceUUIDs, options))

--- a/Tests/FakePeripheral.swift
+++ b/Tests/FakePeripheral.swift
@@ -38,6 +38,10 @@ class FakePeripheral: RxPeripheralType {
     var identifier: UUID = UUID()
     var maximumWriteValueLength = 0
 
+    var peripheral: CBPeripheral {
+        fatalError("Peripheral not available")
+    }
+
     var RSSI: Int? = nil
 
 


### PR DESCRIPTION
It's the change that we've talked about @Cierpliwy.
I wonder about one more thing - should we give user access to `Peripheral` constructor?
```
    init(peripheral: CBPeripheral) {
        self.peripheral = peripheral
        self.internalDelegate = RxCBPeripheral.getInternalPeripheralDelegateRef(cbPeripheral: peripheral)
    }
```
So that user, after using `CBPeripheral` needed by another lib is able to reclaim control over peripheral to our library?
They easily could do it by calling `peripheralsWithIdentifiers` on `BluetoothManager` so I'm not sure whether it's needed