### PR TITLE
Fix Travis for Swift 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode9
 xcode_project: RxBluetoothKit.xcodeproj
 xcode_sdk: iphonesimulator10.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 osx_image: xcode9
 xcode_project: RxBluetoothKit.xcodeproj
-xcode_sdk: iphonesimulator10.0
+xcode_sdk: iphonesimulator11.0
 
 env:
         matrix:


### PR DESCRIPTION
Changed the Xcode version from 8.3 to 9 and simulator from 10 to 11 for Swift 4 support.