### PR TITLE
Write without response advancements 

### DIFF
--- a/Source/BluetoothError.swift
+++ b/Source/BluetoothError.swift
@@ -60,9 +60,9 @@ extension BluetoothError: CustomStringConvertible {
         switch self {
         case .destroyed:
             return """
-                   The object that is the source of this Observable was destroyed.
-                   It's programmer's error, please check documentation of error for more details
-                   """
+            The object that is the source of this Observable was destroyed.
+            It's programmer's error, please check documentation of error for more details
+            """
         case .bluetoothUnsupported:
             return "Bluetooth is unsupported"
         case .bluetoothUnauthorized:

--- a/Source/CBPeripheralDelegateWrapper.swift
+++ b/Source/CBPeripheralDelegateWrapper.swift
@@ -54,6 +54,9 @@ import RxSwift
     var rx_didWriteValueForDescriptor: Observable<(CBDescriptor, Error?)> {
         return peripheralDidWriteValueForDescriptorSubject
     }
+    var rx_peripheralReadyToSendWriteWithoutResponse: Observable<Void> {
+        return peripheralIsReadyToSendWriteWithoutResponseSubject
+    }
 
     private let peripheralDidUpdateNameSubject = PublishSubject<String?>()
     private let peripheralDidModifyServicesSubject = PublishSubject<([CBService])>()
@@ -69,6 +72,7 @@ import RxSwift
         PublishSubject<(CBCharacteristic, Error?)>()
     private let peripheralDidUpdateValueForDescriptorSubject = PublishSubject<(CBDescriptor, Error?)>()
     private let peripheralDidWriteValueForDescriptorSubject = PublishSubject<(CBDescriptor, Error?)>()
+    private let peripheralIsReadyToSendWriteWithoutResponseSubject = PublishSubject<Void>()
 
     @objc func peripheralDidUpdateName(_ peripheral: CBPeripheral) {
         RxBluetoothKitLog.d("""
@@ -193,5 +197,12 @@ import RxSwift
             error: \(String(describing: error)))
             """)
         peripheralDidWriteValueForDescriptorSubject.onNext((descriptor, error))
+    }
+
+    func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        peripheralIsReadyToSendWriteWithoutResponseSubject.onNext(())
+        RxBluetoothKitLog.d("""
+            \(peripheral.logDescription) peripheralIsReady(toSendWriteWithoutResponse)
+            """)
     }
 }

--- a/Source/CBPeripheralDelegateWrapper.swift
+++ b/Source/CBPeripheralDelegateWrapper.swift
@@ -200,9 +200,9 @@ import RxSwift
     }
 
     func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
-        peripheralIsReadyToSendWriteWithoutResponseSubject.onNext(())
         RxBluetoothKitLog.d("""
             \(peripheral.logDescription) peripheralIsReady(toSendWriteWithoutResponse)
             """)
+        peripheralIsReadyToSendWriteWithoutResponseSubject.onNext(())
     }
 }

--- a/Source/Characteristic.swift
+++ b/Source/Characteristic.swift
@@ -65,7 +65,7 @@ public class Characteristic {
     /// Function that triggers descriptors discovery for characteristic.
     /// - returns: `Single` that emits `Next` with array of `Descriptor` instances, once they're discovered.
     public func discoverDescriptors() -> Single<[Descriptor]> {
-        return self.service.peripheral.discoverDescriptors(for: self)
+        return service.peripheral.discoverDescriptors(for: self)
     }
 
     /// Function that allow to monitor writes that happened for characteristic.

--- a/Source/Peripheral+Convenience.swift
+++ b/Source/Peripheral+Convenience.swift
@@ -92,7 +92,7 @@ extension Peripheral {
                     }
                     return characteristic.discoverDescriptors()
                         .map {
-                            if let descriptor = $0.filter({ return $0.uuid == identifier.uuid }).first {
+                            if let descriptor = $0.filter({ $0.uuid == identifier.uuid }).first {
                                 return descriptor
                             }
                             throw RxError.noElements
@@ -168,7 +168,7 @@ extension Peripheral {
     /// - returns: Observable which emits `Next` with Characteristic that state was changed. Immediately after `.Complete` is emitted
     public func setNotifyValue(_ enabled: Bool, for identifier: CharacteristicIdentifier)
         -> Single<Characteristic> {
-            return characteristic(with: identifier)
+        return characteristic(with: identifier)
             .flatMap { [weak self] in
                 self?.setNotifyValue(enabled, for: $0) ?? .error(BluetoothError.destroyed)
             }
@@ -181,11 +181,11 @@ extension Peripheral {
     /// This is **infinite** stream of values.
     public func setNotificationAndMonitorUpdates(for identifier: CharacteristicIdentifier)
         -> Observable<Characteristic> {
-            return characteristic(with: identifier)
-                .asObservable()
-                .flatMap { [weak self] in
-                    self?.setNotificationAndMonitorUpdates(for: $0) ?? .error(BluetoothError.destroyed)
-                }
+        return characteristic(with: identifier)
+            .asObservable()
+            .flatMap { [weak self] in
+                self?.setNotificationAndMonitorUpdates(for: $0) ?? .error(BluetoothError.destroyed)
+            }
     }
 
     /// Function that triggers descriptors discovery for characteristic

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -79,6 +79,13 @@ public class Peripheral {
         }
     }
 
+    /// YES if the remote device has space to send a write without response.  If this value is NO,
+    /// the value will be set to YES after the current writes have been flushed, and
+    /// `peripheralIsReadyToSendWriteWithoutResponse:` will be called.
+    public var canSendWriteWithoutResponse: Bool {
+        return peripheral.canSendWriteWithoutResponse
+    }
+
     /// Establishes local connection to the peripheral.
     /// For more information look into `BluetoothManager.connectToPeripheral(_:options:)` because this method calls it directly.
     /// - Parameter peripheral: The `Peripheral` to which `BluetoothManager` is attempting to connect.
@@ -503,6 +510,12 @@ public class Peripheral {
                 return (strongSelf, services)
             }
         return ensureValidPeripheralState(for: observable)
+    }
+
+    /// Resulting observable emits next element if call to `writeValue:forCharacteristic:type:` has failed,
+    /// to indicate when peripheral is again ready to send characteristic value updates again.
+    public func monitorWriteWithoutResponseReadiness() -> Observable<Void> {
+        return delegateWrapper.rx_peripheralReadyToSendWriteWithoutResponse
     }
 }
 

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -252,8 +252,9 @@ public class Peripheral {
     /// - `withResponse` -  Observable emits `Next` with `Characteristic` instance write was confirmed without any errors.
     /// Immediately after that `Complete` is called. If any problem has happened, errors are emitted.
     /// - `withoutResponse` - Observable emits `Next` with `Characteristic` instance once write was called.
-    /// Immediately after that `.Complete` is called. Result of this call is not checked, so as a user you are not sure if everything completed successfully. Errors are not emitted. It ensures that peripheral is ready to write without
-    /// response by listening to the proper delegate method
+    /// Immediately after that `.Complete` is called. Result of this call is not checked, so as a user you are not sure
+    /// if everything completed successfully. Errors are not emitted. It ensures that peripheral is ready to write
+    /// without response by listening to the proper delegate method
     public func writeValue(_ data: Data,
                            for characteristic: Characteristic,
                            type: CBCharacteristicWriteType) -> Single<Characteristic> {
@@ -271,14 +272,14 @@ public class Peripheral {
         case .withoutResponse:
             return Observable<Characteristic>.deferred { [weak self] in
                 guard let strongSelf = self else { throw BluetoothError.destroyed }
-                let canWrite = strongSelf.monitorWriteWithoutResponseReadiness()
+                return strongSelf.monitorWriteWithoutResponseReadiness()
                     .map { _ in true }
                     .startWith(strongSelf.canSendWriteWithoutResponse)
                     .filter { $0 }
                     .take(1)
-                let observable = writeOperationPerformingAndListeningObservable(Observable.just(characteristic))
-                return canWrite
-                    .flatMap { _ in observable } 
+                    .flatMap { _ in
+                        writeOperationPerformingAndListeningObservable(Observable.just(characteristic))
+                    }
             }.asSingle()
         case .withResponse:
             return writeOperationPerformingAndListeningObservable(monitorWrite(for: characteristic).take(1))

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -112,9 +112,9 @@ public class Peripheral {
     /// - Returns: `Single` that emits `Next` with array of `Service` instances, once they're discovered.
     public func discoverServices(_ serviceUUIDs: [CBUUID]?) -> Single<[Service]> {
         if let identifiers = serviceUUIDs, !identifiers.isEmpty,
-           let cachedServices = self.services,
-           let filteredServices = filterUUIDItems(uuids: serviceUUIDs, items: cachedServices) {
-           return ensureValidPeripheralState(for: .just(filteredServices)).asSingle()
+            let cachedServices = self.services,
+            let filteredServices = filterUUIDItems(uuids: serviceUUIDs, items: cachedServices) {
+            return ensureValidPeripheralState(for: .just(filteredServices)).asSingle()
         }
         let observable = delegateWrapper.rx_didDiscoverServices
             .flatMap { [weak self] (_, error) -> Observable<[Service]> in
@@ -252,23 +252,39 @@ public class Peripheral {
     /// - `withResponse` -  Observable emits `Next` with `Characteristic` instance write was confirmed without any errors.
     /// Immediately after that `Complete` is called. If any problem has happened, errors are emitted.
     /// - `withoutResponse` - Observable emits `Next` with `Characteristic` instance once write was called.
-    /// Immediately after that `.Complete` is called. Result of this call is not checked, so as a user you are not sure if everything completed successfully. Errors are not emitted
+    /// Immediately after that `.Complete` is called. Result of this call is not checked, so as a user you are not sure if everything completed successfully. Errors are not emitted. It ensures that peripheral is ready to write without
+    /// response by listening to the proper delegate method
     public func writeValue(_ data: Data,
                            for characteristic: Characteristic,
                            type: CBCharacteristicWriteType) -> Single<Characteristic> {
-        let observable: Observable<Characteristic>
         switch type {
         case .withoutResponse:
-            observable = .just(characteristic)
+            return Observable<Characteristic>.deferred { [weak self] in
+                guard let strongSelf = self else { throw BluetoothError.destroyed }
+                let canWrite = strongSelf.monitorWriteWithoutResponseReadiness()
+                    .map { _ in true }
+                    .startWith(strongSelf.canSendWriteWithoutResponse)
+                    .filter { $0 }
+                    .take(1)
+                return canWrite
+                    .flatMap { _ -> Observable<Characteristic> in
+                        guard let strongSelf = self else { throw BluetoothError.destroyed }
+                        return strongSelf.ensureValidPeripheralStateAndCallIfSucceeded(
+                            for: .just(characteristic),
+                            postSubscriptionCall: { [weak self] in
+                                self?.peripheral.writeValue(data, for: characteristic.characteristic, type: type)
+                            }
+                        )
+                    }
+            }.asSingle()
         case .withResponse:
-            observable = monitorWrite(for: characteristic).take(1)
+            return ensureValidPeripheralStateAndCallIfSucceeded(
+                for: monitorWrite(for: characteristic).take(1),
+                postSubscriptionCall: { [weak self] in
+                    self?.peripheral.writeValue(data, for: characteristic.characteristic, type: type)
+                }
+            ).asSingle()
         }
-        return ensureValidPeripheralStateAndCallIfSucceeded(
-            for: observable,
-            postSubscriptionCall: { [weak self] in
-                self?.peripheral.writeValue(data, for: characteristic.characteristic, type: type)
-            }
-        ).asSingle()
     }
 
     /// Function that allow to monitor value updates for `Characteristic` instance.
@@ -293,7 +309,7 @@ public class Peripheral {
     /// - Parameter characteristic: `Characteristic` to read value from
     /// - Returns: `Single` which emits `Next` with given characteristic when value is ready to read.
     public func readValue(for characteristic: Characteristic) -> Single<Characteristic> {
-        let observable = self.monitorValueUpdate(for: characteristic).take(1)
+        let observable = monitorValueUpdate(for: characteristic).take(1)
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in
@@ -336,17 +352,17 @@ public class Peripheral {
     /// This is **infinite** stream of values.
     public func setNotificationAndMonitorUpdates(for characteristic: Characteristic)
         -> Observable<Characteristic> {
-            return Observable
-                .of(
-                    monitorValueUpdate(for: characteristic),
-                    setNotifyValue(true, for: characteristic)
-                        .asObservable()
-                        .ignoreElements()
-                        .asObservable()
-                        .map { _ in characteristic }
-                        .subscribeOn(CurrentThreadScheduler.instance)
-                )
-                .merge()
+        return Observable
+            .of(
+                monitorValueUpdate(for: characteristic),
+                setNotifyValue(true, for: characteristic)
+                    .asObservable()
+                    .ignoreElements()
+                    .asObservable()
+                    .map { _ in characteristic }
+                    .subscribeOn(CurrentThreadScheduler.instance)
+            )
+            .merge()
     }
 
     // MARK: Descriptors
@@ -417,7 +433,7 @@ public class Peripheral {
     /// - Parameter descriptor: `Descriptor` to read value from
     /// - Returns: `Single` which emits `Next` with given descriptor when value is ready to read.
     public func readValue(for descriptor: Descriptor) -> Single<Descriptor> {
-        let observable = self.monitorValueUpdate(for: descriptor).take(1)
+        let observable = monitorValueUpdate(for: descriptor).take(1)
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in


### PR DESCRIPTION
I've exposed the API call & delegate method for checking readiness of peripheral to write without response. It's integrated into our current write method, too.
Partially addresses #169 