### PR TITLE
Peripheral mode — basic setup, few methods implemented

### DIFF
--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		2666FE291CCE4731005E81CE /* Boxes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0F1CBE3DEE005DEA5B /* Boxes.swift */; };
 		2666FE2A1CCE4731005E81CE /* BluetoothError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0D1CBE3DEE005DEA5B /* BluetoothError.swift */; };
 		2666FE2B1CCE4731005E81CE /* ScanOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C221CBE3DEE005DEA5B /* ScanOperation.swift */; };
-		2666FE2E1CCE4731005E81CE /* BluetoothManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0E1CBE3DEE005DEA5B /* BluetoothManager.swift */; };
+		2666FE2E1CCE4731005E81CE /* CentralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0E1CBE3DEE005DEA5B /* CentralManager.swift */; };
 		2666FE2F1CCE4731005E81CE /* AdvertisementData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0C1CBE3DEE005DEA5B /* AdvertisementData.swift */; };
 		2666FE321CCE4732005E81CE /* Descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C121CBE3DEE005DEA5B /* Descriptor.swift */; };
 		2666FE341CCE4732005E81CE /* ScannedPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C211CBE3DEE005DEA5B /* ScannedPeripheral.swift */; };
@@ -42,7 +42,7 @@
 		2666FE441CCE4732005E81CE /* Boxes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0F1CBE3DEE005DEA5B /* Boxes.swift */; };
 		2666FE451CCE4732005E81CE /* BluetoothError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0D1CBE3DEE005DEA5B /* BluetoothError.swift */; };
 		2666FE461CCE4732005E81CE /* ScanOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C221CBE3DEE005DEA5B /* ScanOperation.swift */; };
-		2666FE491CCE4732005E81CE /* BluetoothManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0E1CBE3DEE005DEA5B /* BluetoothManager.swift */; };
+		2666FE491CCE4732005E81CE /* CentralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0E1CBE3DEE005DEA5B /* CentralManager.swift */; };
 		2666FE4A1CCE4732005E81CE /* AdvertisementData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0C1CBE3DEE005DEA5B /* AdvertisementData.swift */; };
 		26752FA61D89C630003D8D38 /* BluetoothState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EF38C81D86EE1F00F9F468 /* BluetoothState.swift */; };
 		26EF38C91D86EE1F00F9F468 /* BluetoothState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EF38C81D86EE1F00F9F468 /* BluetoothState.swift */; };
@@ -55,6 +55,10 @@
 		A10F29A51CDCD75900593284 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10F29991CDCD73A00593284 /* Quick.framework */; };
 		A10F29AD1CDCD98400593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5A1CCE65CD005E81CE /* RxSwift.framework */; };
 		A10F29B01CDCD99900593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5E1CCE65EE005E81CE /* RxSwift.framework */; };
+		BB24D3961F9F74620006B481 /* PeripheralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB24D3951F9F74620006B481 /* PeripheralManager.swift */; };
+		BB24D3971F9F74620006B481 /* PeripheralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB24D3951F9F74620006B481 /* PeripheralManager.swift */; };
+		BB24D3991F9F74AF0006B481 /* CBPeripheralManagerDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB24D3981F9F74AF0006B481 /* CBPeripheralManagerDelegateWrapper.swift */; };
+		BB24D39A1F9F74AF0006B481 /* CBPeripheralManagerDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB24D3981F9F74AF0006B481 /* CBPeripheralManagerDelegateWrapper.swift */; };
 		BB2FF3321F9EAD5300A12E10 /* CBPeripheralDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2FF3311F9EAD5300A12E10 /* CBPeripheralDelegateWrapper.swift */; };
 		BB2FF3331F9EAF1600A12E10 /* CBPeripheralDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2FF3311F9EAD5300A12E10 /* CBPeripheralDelegateWrapper.swift */; };
 		BB2FF3351F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2FF3341F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift */; };
@@ -128,7 +132,7 @@
 		A10F299A1CDCD73A00593284 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		A1299C0C1CBE3DEE005DEA5B /* AdvertisementData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdvertisementData.swift; sourceTree = "<group>"; };
 		A1299C0D1CBE3DEE005DEA5B /* BluetoothError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BluetoothError.swift; sourceTree = "<group>"; };
-		A1299C0E1CBE3DEE005DEA5B /* BluetoothManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = BluetoothManager.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		A1299C0E1CBE3DEE005DEA5B /* CentralManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = CentralManager.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A1299C0F1CBE3DEE005DEA5B /* Boxes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Boxes.swift; sourceTree = "<group>"; };
 		A1299C101CBE3DEE005DEA5B /* Characteristic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Characteristic.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A1299C121CBE3DEE005DEA5B /* Descriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Descriptor.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -139,6 +143,8 @@
 		A1299C221CBE3DEE005DEA5B /* ScanOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanOperation.swift; sourceTree = "<group>"; };
 		A1299C231CBE3DEE005DEA5B /* Service.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		A1299C241CBE3DEE005DEA5B /* Unimplemented.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Unimplemented.swift; sourceTree = "<group>"; };
+		BB24D3951F9F74620006B481 /* PeripheralManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeripheralManager.swift; sourceTree = "<group>"; };
+		BB24D3981F9F74AF0006B481 /* CBPeripheralManagerDelegateWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBPeripheralManagerDelegateWrapper.swift; sourceTree = "<group>"; };
 		BB2FF3311F9EAD5300A12E10 /* CBPeripheralDelegateWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBPeripheralDelegateWrapper.swift; sourceTree = "<group>"; };
 		BB2FF3341F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBCentralManagerDelegateWrapper.swift; sourceTree = "<group>"; };
 		D74B16841ED417AA006D5996 /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
@@ -187,17 +193,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		265CD5F91CBED2E4007120AB /* BluetoothManager */ = {
+		265CD5F91CBED2E4007120AB /* CentralManager */ = {
 			isa = PBXGroup;
 			children = (
 				A1299C221CBE3DEE005DEA5B /* ScanOperation.swift */,
-				A1299C0E1CBE3DEE005DEA5B /* BluetoothManager.swift */,
+				A1299C0E1CBE3DEE005DEA5B /* CentralManager.swift */,
 				A1299C0C1CBE3DEE005DEA5B /* AdvertisementData.swift */,
 				26F3034A1CF0D49D00D74EBF /* RestoredState.swift */,
 				26EF38C81D86EE1F00F9F468 /* BluetoothState.swift */,
 				BB2FF3341F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift */,
 			);
-			name = BluetoothManager;
+			name = CentralManager;
 			sourceTree = "<group>";
 		};
 		265CD5FA1CBED323007120AB /* Shared */ = {
@@ -356,12 +362,13 @@
 		A1299BD71CBE3D61005DEA5B /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				BB24D3941F9F73D30006B481 /* PeripheralManager */,
 				265CD5FE1CBED348007120AB /* Descriptor */,
 				265CD5FD1CBED33D007120AB /* Peripheral */,
 				265CD5FC1CBED339007120AB /* Service */,
 				265CD5FB1CBED333007120AB /* Characteristic */,
 				265CD5FA1CBED323007120AB /* Shared */,
-				265CD5F91CBED2E4007120AB /* BluetoothManager */,
+				265CD5F91CBED2E4007120AB /* CentralManager */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -374,6 +381,15 @@
 			);
 			name = Frameworks;
 			path = RxBluetoothKit;
+			sourceTree = "<group>";
+		};
+		BB24D3941F9F73D30006B481 /* PeripheralManager */ = {
+			isa = PBXGroup;
+			children = (
+				BB24D3951F9F74620006B481 /* PeripheralManager.swift */,
+				BB24D3981F9F74AF0006B481 /* CBPeripheralManagerDelegateWrapper.swift */,
+			);
+			name = PeripheralManager;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -581,7 +597,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2666FE3F1CCE4732005E81CE /* Observable+QueueSubscribeOn.swift in Sources */,
-				2666FE491CCE4732005E81CE /* BluetoothManager.swift in Sources */,
+				2666FE491CCE4732005E81CE /* CentralManager.swift in Sources */,
 				2666FE401CCE4732005E81CE /* Unimplemented.swift in Sources */,
 				2666FE371CCE4732005E81CE /* DeviceIdentifiers.swift in Sources */,
 				26EF38C91D86EE1F00F9F468 /* BluetoothState.swift in Sources */,
@@ -595,12 +611,14 @@
 				2666FE3A1CCE4732005E81CE /* Service.swift in Sources */,
 				2666FE451CCE4732005E81CE /* BluetoothError.swift in Sources */,
 				FA947A3B1EB1C41C000ED0B1 /* UUIDIdentifiable.swift in Sources */,
+				BB24D3961F9F74620006B481 /* PeripheralManager.swift in Sources */,
 				2666FE3E1CCE4732005E81CE /* Characteristic.swift in Sources */,
 				2666FE321CCE4732005E81CE /* Descriptor.swift in Sources */,
 				2666FE4A1CCE4732005E81CE /* AdvertisementData.swift in Sources */,
 				2666FE421CCE4732005E81CE /* Observable+Absorb.swift in Sources */,
 				2666FE341CCE4732005E81CE /* ScannedPeripheral.swift in Sources */,
 				26F3034B1CF0D49D00D74EBF /* RestoredState.swift in Sources */,
+				BB24D3991F9F74AF0006B481 /* CBPeripheralManagerDelegateWrapper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -618,7 +636,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2666FE241CCE4731005E81CE /* Observable+QueueSubscribeOn.swift in Sources */,
-				2666FE2E1CCE4731005E81CE /* BluetoothManager.swift in Sources */,
+				2666FE2E1CCE4731005E81CE /* CentralManager.swift in Sources */,
 				2666FE251CCE4731005E81CE /* Unimplemented.swift in Sources */,
 				D74B16861ED417AA006D5996 /* Logging.swift in Sources */,
 				2666FE1C1CCE4731005E81CE /* DeviceIdentifiers.swift in Sources */,
@@ -629,6 +647,7 @@
 				2666FE291CCE4731005E81CE /* Boxes.swift in Sources */,
 				2666FE1D1CCE4731005E81CE /* Peripheral+Convenience.swift in Sources */,
 				BB2FF3331F9EAF1600A12E10 /* CBPeripheralDelegateWrapper.swift in Sources */,
+				BB24D3971F9F74620006B481 /* PeripheralManager.swift in Sources */,
 				26752FA61D89C630003D8D38 /* BluetoothState.swift in Sources */,
 				2666FE1F1CCE4731005E81CE /* Service.swift in Sources */,
 				2666FE2A1CCE4731005E81CE /* BluetoothError.swift in Sources */,
@@ -637,6 +656,7 @@
 				2666FE2F1CCE4731005E81CE /* AdvertisementData.swift in Sources */,
 				2666FE271CCE4731005E81CE /* Observable+Absorb.swift in Sources */,
 				2666FE191CCE4731005E81CE /* ScannedPeripheral.swift in Sources */,
+				BB24D39A1F9F74AF0006B481 /* CBPeripheralManagerDelegateWrapper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		BB2FF3331F9EAF1600A12E10 /* CBPeripheralDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2FF3311F9EAD5300A12E10 /* CBPeripheralDelegateWrapper.swift */; };
 		BB2FF3351F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2FF3341F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift */; };
 		BB2FF3361F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2FF3341F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift */; };
+		BB701D131FA1E99E00A1D4E7 /* Managers+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB701D121FA1E99E00A1D4E7 /* Managers+State.swift */; };
 		D74B16851ED417AA006D5996 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74B16841ED417AA006D5996 /* Logging.swift */; };
 		D74B16861ED417AA006D5996 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74B16841ED417AA006D5996 /* Logging.swift */; };
 		FA947A3B1EB1C41C000ED0B1 /* UUIDIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */; };
@@ -147,6 +148,7 @@
 		BB24D3981F9F74AF0006B481 /* CBPeripheralManagerDelegateWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBPeripheralManagerDelegateWrapper.swift; sourceTree = "<group>"; };
 		BB2FF3311F9EAD5300A12E10 /* CBPeripheralDelegateWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBPeripheralDelegateWrapper.swift; sourceTree = "<group>"; };
 		BB2FF3341F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBCentralManagerDelegateWrapper.swift; sourceTree = "<group>"; };
+		BB701D121FA1E99E00A1D4E7 /* Managers+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Managers+State.swift"; sourceTree = "<group>"; };
 		D74B16841ED417AA006D5996 /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UUIDIdentifiable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -216,6 +218,7 @@
 				A1299C0D1CBE3DEE005DEA5B /* BluetoothError.swift */,
 				FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */,
 				D74B16841ED417AA006D5996 /* Logging.swift */,
+				BB701D121FA1E99E00A1D4E7 /* Managers+State.swift */,
 			);
 			name = Shared;
 			sourceTree = "<group>";
@@ -605,6 +608,7 @@
 				BB2FF3351F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift in Sources */,
 				2666FE351CCE4732005E81CE /* Peripheral.swift in Sources */,
 				D74B16851ED417AA006D5996 /* Logging.swift in Sources */,
+				BB701D131FA1E99E00A1D4E7 /* Managers+State.swift in Sources */,
 				2666FE441CCE4732005E81CE /* Boxes.swift in Sources */,
 				BB2FF3321F9EAD5300A12E10 /* CBPeripheralDelegateWrapper.swift in Sources */,
 				2666FE381CCE4732005E81CE /* Peripheral+Convenience.swift in Sources */,

--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		BB2FF3351F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2FF3341F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift */; };
 		BB2FF3361F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2FF3341F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift */; };
 		BB701D131FA1E99E00A1D4E7 /* Managers+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB701D121FA1E99E00A1D4E7 /* Managers+State.swift */; };
+		BB701D141FA296FF00A1D4E7 /* Managers+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB701D121FA1E99E00A1D4E7 /* Managers+State.swift */; };
 		D74B16851ED417AA006D5996 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74B16841ED417AA006D5996 /* Logging.swift */; };
 		D74B16861ED417AA006D5996 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74B16841ED417AA006D5996 /* Logging.swift */; };
 		FA947A3B1EB1C41C000ED0B1 /* UUIDIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */; };
@@ -655,6 +656,7 @@
 				26752FA61D89C630003D8D38 /* BluetoothState.swift in Sources */,
 				2666FE1F1CCE4731005E81CE /* Service.swift in Sources */,
 				2666FE2A1CCE4731005E81CE /* BluetoothError.swift in Sources */,
+				BB701D141FA296FF00A1D4E7 /* Managers+State.swift in Sources */,
 				2666FE231CCE4731005E81CE /* Characteristic.swift in Sources */,
 				2666FE171CCE4731005E81CE /* Descriptor.swift in Sources */,
 				2666FE2F1CCE4731005E81CE /* AdvertisementData.swift in Sources */,

--- a/Source/BluetoothError.swift
+++ b/Source/BluetoothError.swift
@@ -51,6 +51,9 @@ public enum BluetoothError: Error {
     case descriptorsDiscoveryFailed(Characteristic, Error?)
     case descriptorWriteFailed(Descriptor, Error?)
     case descriptorReadFailed(Descriptor, Error?)
+    // Peripheral Mode
+    case peripheralAlreadyAdvertising
+    case peripheralAdvertisingFailed(Error)
 }
 
 extension BluetoothError: CustomStringConvertible {
@@ -101,6 +104,10 @@ extension BluetoothError: CustomStringConvertible {
             return "Descriptor write error has occured: \(err?.localizedDescription ?? "-")"
         case let .descriptorReadFailed(_, err):
             return "Descriptor read error has occured: \(err?.localizedDescription ?? "-")"
+        case .peripheralAlreadyAdvertising:
+            return "Peripheral is already advertising. Make sure to stop advertising before calling this method"
+        case let .peripheralAdvertisingFailed(err):
+            return "Peripheral start advertising error has occured: \(err.localizedDescription)"
         }
     }
 }
@@ -151,6 +158,8 @@ public func == (lhs: BluetoothError, rhs: BluetoothError) -> Bool {
     case let (.descriptorsDiscoveryFailed(l, _), .descriptorsDiscoveryFailed(r, _)): return l == r
     case let (.descriptorWriteFailed(l, _), .descriptorWriteFailed(r, _)): return l == r
     case let (.descriptorReadFailed(l, _), .descriptorReadFailed(r, _)): return l == r
+    case (.peripheralAlreadyAdvertising, .peripheralAlreadyAdvertising): return true
+    case (.peripheralAdvertisingFailed(_), .peripheralAdvertisingFailed(_)): return true
     default: return false
     }
 }

--- a/Source/BluetoothError.swift
+++ b/Source/BluetoothError.swift
@@ -60,9 +60,9 @@ extension BluetoothError: CustomStringConvertible {
         switch self {
         case .destroyed:
             return """
-                   The object that is the source of this Observable was destroyed.
-                   It's programmer's error, please check documentation of error for more details
-                   """
+            The object that is the source of this Observable was destroyed.
+            It's programmer's error, please check documentation of error for more details
+            """
         case .bluetoothUnsupported:
             return "Bluetooth is unsupported"
         case .bluetoothUnauthorized:

--- a/Source/CBPeripheralManagerDelegateWrapper.swift
+++ b/Source/CBPeripheralManagerDelegateWrapper.swift
@@ -83,31 +83,67 @@ import RxSwift
         willRestoreStateSubject.onNext(dict)
     }
 
-    func peripheralManagerDidStartAdvertising(_: CBPeripheralManager, error: Error?) {
+    func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: Error?) {
+        RxBluetoothKitLog.d("""
+                            \(peripheral.logDescription) didStartAdvertising
+                            (error: \(String(describing: error))")
+                            """)
         didStartAdvertisingSubject.onNext(error)
     }
 
-    func peripheralManager(_: CBPeripheralManager, didAdd _: CBService, error: Error?) {
+    func peripheralManager(_ peripheral: CBPeripheralManager, didAdd service: CBService, error: Error?) {
+        RxBluetoothKitLog.d("""
+                            \(peripheral.logDescription) didAddService: \(service.logDescription)
+                            (error: \(String(describing: error))")
+                            """)
         didAddServiceSubject.onNext(error)
     }
 
-    func peripheralManager(_: CBPeripheralManager, central: CBCentral, didSubscribeTo characteristic: CBCharacteristic) {
+    func peripheralManager(
+        _ peripheral: CBPeripheralManager,
+        central: CBCentral,
+        didSubscribeTo characteristic: CBCharacteristic
+        ) {
+        RxBluetoothKitLog.d("""
+                            \(peripheral.logDescription) central: \(central)
+                            didSubscribeTo: \(characteristic.logDescription)
+                            """)
         didSubscribeToCharacteristicSubject.onNext((central, characteristic))
     }
 
-    func peripheralManager(_: CBPeripheralManager, central: CBCentral, didUnsubscribeFrom characteristic: CBCharacteristic) {
+    func peripheralManager(
+        _ peripheral: CBPeripheralManager,
+        central: CBCentral,
+        didUnsubscribeFrom characteristic: CBCharacteristic
+        ) {
+        RxBluetoothKitLog.d("""
+                            \(peripheral.logDescription) central: \(central)
+                            didSubscribeTo: \(characteristic.logDescription)
+                            """)
         didUnsubscribeFromCharacteristicSubject.onNext((central, characteristic))
     }
 
-    func peripheralManager(_: CBPeripheralManager, didReceiveRead request: CBATTRequest) {
+    func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveRead request: CBATTRequest) {
+        RxBluetoothKitLog.d("""
+                            \(peripheral.logDescription)
+                            didReceiveRead: \(request.logDescription)
+                            """)
         didReceiveReadSubject.onNext(request)
     }
 
-    func peripheralManager(_: CBPeripheralManager, didReceiveWrite request: [CBATTRequest]) {
+    func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveWrite request: [CBATTRequest]) {
+        RxBluetoothKitLog.d("""
+                            \(peripheral.logDescription)
+                            didReceiveWriteRequest: \(request.logDescription)
+                            """)
         didReceiveWriteSubject.onNext(request)
     }
 
-    func peripheralManagerIsReady(toUpdateSubscribers _: CBPeripheralManager) {
+    func peripheralManagerIsReady(toUpdateSubscribers peripheral: CBPeripheralManager) {
+        RxBluetoothKitLog.d("""
+                            \(peripheral.logDescription)
+                            isReadyToUpdateSubscribers:
+                            """)
         isReadyToUpdateSubscribersSubject.onNext(())
     }
 }

--- a/Source/CBPeripheralManagerDelegateWrapper.swift
+++ b/Source/CBPeripheralManagerDelegateWrapper.swift
@@ -1,0 +1,113 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import CoreBluetooth
+import RxSwift
+
+@objc class CBPeripheralManagerDelegateWrapper: NSObject, CBPeripheralManagerDelegate {
+
+    var rx_didUpdateState: Observable<BluetoothState> {
+        return didUpdateStateSubject
+    }
+
+    var rx_willRestoreState: Observable<[String: Any]> {
+        return willRestoreStateSubject
+    }
+
+    var rx_didStartAdvertising: Observable<Error?> {
+        return didStartAdvertisingSubject
+    }
+
+    var rx_didAddService: Observable<Error?> {
+        return didAddServiceSubject
+    }
+
+    var rx_didSubscribeToCharacteristic: Observable<(CBCentral, CBCharacteristic)> {
+        return didSubscribeToCharacteristicSubject
+    }
+
+    var rx_didUnsubscribeFromCharacteristic: Observable<(CBCentral, CBCharacteristic)> {
+        return didUnsubscribeFromCharacteristicSubject
+    }
+
+    var rx_didAddReceiveRead: Observable<CBATTRequest> {
+        return didReceiveReadSubject
+    }
+
+    var rx_didReceiveWrite: Observable<[CBATTRequest]> {
+        return didReceiveWriteSubject
+    }
+
+    var rx_isReadyToUpdateSubscribers: Observable<Void> {
+        return isReadyToUpdateSubscribersSubject
+    }
+
+    private let didUpdateStateSubject = PublishSubject<BluetoothState>()
+    private let willRestoreStateSubject = ReplaySubject<[String: Any]>.create(bufferSize: 1)
+    private let didStartAdvertisingSubject = PublishSubject<Error?>()
+    private let didAddServiceSubject = PublishSubject<Error?>()
+    private let didSubscribeToCharacteristicSubject = PublishSubject<(CBCentral, CBCharacteristic)>()
+    private let didUnsubscribeFromCharacteristicSubject = PublishSubject<(CBCentral, CBCharacteristic)>()
+    private let didReceiveReadSubject = PublishSubject<CBATTRequest>()
+    private let didReceiveWriteSubject = PublishSubject<[CBATTRequest]>()
+    private let isReadyToUpdateSubscribersSubject = PublishSubject<Void>()
+
+    func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+        guard let bleState = BluetoothState(rawValue: peripheral.state.rawValue) else { return }
+        RxBluetoothKitLog.d("\(peripheral.logDescription) didUpdateState(state: \(bleState.logDescription))")
+        didUpdateStateSubject.onNext(bleState)
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, willRestoreState dict: [String: Any]) {
+        RxBluetoothKitLog.d("\(peripheral.logDescription) willRestoreState(restoredState: \(dict))")
+        willRestoreStateSubject.onNext(dict)
+    }
+
+    func peripheralManagerDidStartAdvertising(_: CBPeripheralManager, error: Error?) {
+        didStartAdvertisingSubject.onNext(error)
+    }
+
+    func peripheralManager(_: CBPeripheralManager, didAdd _: CBService, error: Error?) {
+        didAddServiceSubject.onNext(error)
+    }
+
+    func peripheralManager(_: CBPeripheralManager, central: CBCentral, didSubscribeTo characteristic: CBCharacteristic) {
+        didSubscribeToCharacteristicSubject.onNext((central, characteristic))
+    }
+
+    func peripheralManager(_: CBPeripheralManager, central: CBCentral, didUnsubscribeFrom characteristic: CBCharacteristic) {
+        didUnsubscribeFromCharacteristicSubject.onNext((central, characteristic))
+    }
+
+    func peripheralManager(_: CBPeripheralManager, didReceiveRead request: CBATTRequest) {
+        didReceiveReadSubject.onNext(request)
+    }
+
+    func peripheralManager(_: CBPeripheralManager, didReceiveWrite request: [CBATTRequest]) {
+        didReceiveWriteSubject.onNext(request)
+    }
+
+    func peripheralManagerIsReady(toUpdateSubscribers _: CBPeripheralManager) {
+        isReadyToUpdateSubscribersSubject.onNext(())
+    }
+}

--- a/Source/CBPeripheralManagerDelegateWrapper.swift
+++ b/Source/CBPeripheralManagerDelegateWrapper.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016 Polidea
+// Copyright (c) 2017 Polidea
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Source/CentralManager.swift
+++ b/Source/CentralManager.swift
@@ -168,7 +168,7 @@ public class CentralManager: BluetoothStateProvider {
                 return operation
             }()
             // Allow scanning as long as bluetooth is powered on
-            return strongSelf.ensure(state: .poweredOn, observable: observable)
+            return strongSelf.ensure(state: .poweredOn, for: observable)
         }
     }
 
@@ -239,7 +239,7 @@ public class CentralManager: BluetoothStateProvider {
             }
         }
 
-            return ensure(state: .poweredOn, observable: observable).asSingle()
+            return ensure(state: .poweredOn, for: observable).asSingle()
     }
 
     /// Cancels an active or pending local connection to a `Peripheral` after observable subscription. It is not guaranteed
@@ -258,7 +258,7 @@ public class CentralManager: BluetoothStateProvider {
             strongSelf.centralManager.cancelPeripheralConnection(peripheral.peripheral)
             return disposable
         }
-        return ensure(state: .poweredOn, observable: observable).asSingle()
+        return ensure(state: .poweredOn, for: observable).asSingle()
     }
 
     // MARK: Retrieving Lists of Peripherals
@@ -280,7 +280,7 @@ public class CentralManager: BluetoothStateProvider {
                     }
                 }
         }
-        return ensure(state: .poweredOn, observable: observable).asSingle()
+        return ensure(state: .poweredOn, for: observable).asSingle()
     }
 
     /// Returns observable list of `Peripheral`s by their identifiers which are known to `CentralManager`.
@@ -298,7 +298,7 @@ public class CentralManager: BluetoothStateProvider {
                     }
                 }
         }
-        return ensure(state: .poweredOn, observable: observable).asSingle()
+        return ensure(state: .poweredOn, for: observable).asSingle()
     }
 
     // MARK: Internal functions
@@ -339,7 +339,7 @@ public class CentralManager: BluetoothStateProvider {
             peripheralAction
             .filter { $0 == peripheral.peripheral }
             .map { _ in peripheral }
-            return ensure(state: .poweredOn, observable: observable)
+            return ensure(state: .poweredOn, for: observable)
     }
 
     #if os(iOS)

--- a/Source/CentralManager.swift
+++ b/Source/CentralManager.swift
@@ -29,7 +29,7 @@ import CoreBluetooth
 /// BluetoothManager is a class implementing ReactiveX API which wraps all Core Bluetooth Manager's functions allowing to
 /// discover, connect to remote peripheral devices and more.
 /// You can start using this class by discovering available services of nearby peripherals. Before calling any
-/// public `BluetoothManager`'s functions you should make sure that Bluetooth is turned on and powered on. It can be done
+/// public `CentralManager`'s functions you should make sure that Bluetooth is turned on and powered on. It can be done
 /// by calling and observing returned value of `monitorState()` and then chaining it with `scanForPeripherals(_:options:)`:
 /// ```
 /// bluetoothManager.rx_state
@@ -40,9 +40,8 @@ import CoreBluetooth
 /// As a result you will receive `ScannedPeripheral` which contains `Peripheral` object, `AdvertisementData` and
 /// peripheral's RSSI registered during discovery. You can then `connectToPeripheral(_:options:)` and do other operations.
 /// - seealso: `Peripheral`
-public class BluetoothManager {
+public class CentralManager {
 
-    /// Implementation of Central Manager
     public let centralManager: CBCentralManager
 
     private let delegateWrapper = CBCentralManagerDelegateWrapper()
@@ -57,8 +56,7 @@ public class BluetoothManager {
     private var scanQueue: [ScanOperation] = []
 
     // MARK: Initialization
-
-    /// Creates new `BluetoothManager`
+    /// Creates new `CentralManager`
     /// - parameter centralManager: Central instance which is used to perform all of the necessary operations
     /// - parameter queueScheduler: Scheduler on which all serialised operations are executed (such as scans). By default main thread is used.
     init(centralManager: CBCentralManager,
@@ -68,7 +66,7 @@ public class BluetoothManager {
         centralManager.delegate = delegateWrapper
     }
 
-    /// Creates new `BluetoothManager` instance. By default all operations and events are executed and received on main thread.
+    /// Creates new `CentralManager` instance. By default all operations and events are executed and received on main thread.
     /// - warning: If you pass background queue to the method make sure to observe results on main thread for UI related code.
     /// - parameter queue: Queue on which bluetooth callbacks are received. By default main thread is used.
     /// - parameter options: An optional dictionary containing initialization options for a central manager.
@@ -176,7 +174,7 @@ public class BluetoothManager {
 
     // MARK: State
 
-    /// Continuous state of `BluetoothManager` instance described by `BluetoothState` which is equivalent to  [CBManagerState](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
+    /// Continuous state of `CentralManager` instance described by `BluetoothState` which is equivalent to  [CBManagerState](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
     /// - returns: Observable that emits `Next` immediately after subscribtion with current state of Bluetooth. Later,
     /// whenever state changes events are emitted. Observable is infinite : doesn't generate `Complete`.
     public var rx_state: Observable<BluetoothState> {
@@ -186,8 +184,8 @@ public class BluetoothManager {
         }
     }
 
-    /// Current state of `BluetoothManager` instance described by `BluetoothState` which is equivalent to [CBManagerState](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
-    /// - returns: Current state of `BluetoothManager` as `BluetoothState`.
+    /// Current state of `CentralManager` instance described by `BluetoothState` which is equivalent to [CBManagerState](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
+    /// - returns: Current state of `CentralManager` as `BluetoothState`.
     public var state: BluetoothState {
         return BluetoothState(rawValue: centralManager.state.rawValue) ?? .unsupported
     }
@@ -199,7 +197,7 @@ public class BluetoothManager {
     /// returned observable cancels connection attempt. By default observable is waiting infinitely for successful connection.
     /// Additionally you can pass optional [dictionary](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/#//apple_ref/doc/constant_group/Peripheral_Connection_Options)
     /// to customise the behaviour of connection.
-    /// - parameter peripheral: The `Peripheral` to which `BluetoothManager` is attempting to connect.
+    /// - parameter peripheral: The `Peripheral` to which `CentralManager` is attempting to connect.
     /// - parameter options: Dictionary to customise the behaviour of connection.
     /// - returns: `Single` which emits next event after connection is established.
     public func connect(_ peripheral: Peripheral, options: [String: Any]? = nil)
@@ -252,7 +250,7 @@ public class BluetoothManager {
     /// Cancels an active or pending local connection to a `Peripheral` after observable subscription. It is not guaranteed
     /// that physical connection will be closed immediately as well and all pending commands will not be executed.
     ///
-    /// - parameter peripheral: The `Peripheral` to which the `BluetoothManager` is either trying to
+    /// - parameter peripheral: The `Peripheral` to which the `CentralManager` is either trying to
     /// connect or has already connected.
     /// - returns: `Single` which emits next event when peripheral successfully cancelled connection.
     public func cancelPeripheralConnection(_ peripheral: Peripheral) -> Single<Peripheral> {
@@ -270,7 +268,7 @@ public class BluetoothManager {
 
     // MARK: Retrieving Lists of Peripherals
 
-    /// Returns observable list of the `Peripheral`s which are currently connected to the `BluetoothManager` and contain
+    /// Returns observable list of the `Peripheral`s which are currently connected to the `CentralManager` and contain
     /// all of the specified `Service`'s UUIDs.
     ///
     /// - parameter serviceUUIDs: A list of `Service` UUIDs
@@ -290,7 +288,7 @@ public class BluetoothManager {
         return ensure(.poweredOn, observable: observable).asSingle()
     }
 
-    /// Returns observable list of `Peripheral`s by their identifiers which are known to `BluetoothManager`.
+    /// Returns observable list of `Peripheral`s by their identifiers which are known to `CentralManager`.
     ///
     /// - parameter identifiers: List of `Peripheral`'s identifiers which should be retrieved.
     /// - returns: `Single` which emits next event when list of `Peripheral`s are retrieved.
@@ -310,7 +308,7 @@ public class BluetoothManager {
 
     // MARK: Internal functions
 
-    /// Ensure that `state` is and will be the only state of `BluetoothManager` during subscription.
+    /// Ensure that `state` is and will be the only state of `CentralManager` during subscription.
     /// Otherwise error is emitted.
     /// - parameter state: `BluetoothState` which should be present during subscription.
     /// - parameter observable: Observable into which potential errors should be merged.
@@ -362,7 +360,7 @@ public class BluetoothManager {
     }
 
     #if os(iOS)
-        /// Emits `RestoredState` instance, when state of `BluetoothManager` has been restored,
+        /// Emits `RestoredState` instance, when state of `CentralManager` has been restored,
         /// Should only be called once in the lifetime of the app
         /// - Returns: Observable which emits next events state has been restored
         public func listenOnRestoredState() -> Observable<RestoredState> {
@@ -371,7 +369,7 @@ public class BluetoothManager {
                 .take(1)
                 .flatMap { [weak self] dict -> Observable<RestoredState> in
                     guard let strongSelf = self else { throw BluetoothError.destroyed }
-                    return .just(RestoredState(restoredStateDictionary: dict, bluetoothManager: strongSelf))
+                    return .just(RestoredState(restoredStateDictionary: dict, centralManager: strongSelf))
                 }
         }
     #endif

--- a/Source/Characteristic.swift
+++ b/Source/Characteristic.swift
@@ -65,7 +65,7 @@ public class Characteristic {
     /// Function that triggers descriptors discovery for characteristic.
     /// - returns: `Single` that emits `Next` with array of `Descriptor` instances, once they're discovered.
     public func discoverDescriptors() -> Single<[Descriptor]> {
-        return self.service.peripheral.discoverDescriptors(for: self)
+        return service.peripheral.discoverDescriptors(for: self)
     }
 
     /// Function that allow to monitor writes that happened for characteristic.

--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -154,6 +154,12 @@ extension CBCentralManager: Loggable {
     }
 }
 
+extension CBPeripheralManager: Loggable {
+    @objc var logDescription: String {
+        return "PeripheralManager(\(UInt(bitPattern: ObjectIdentifier(self))))"
+    }
+}
+
 extension CBPeripheral: Loggable {
     @objc var logDescription: String {
         return "Peripheral(uuid: \(value(forKey: "identifier") as! NSUUID as UUID), name: \(String(describing: name)))"

--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -198,6 +198,16 @@ extension CBDescriptor: Loggable {
     }
 }
 
+extension CBATTRequest: Loggable {
+    @objc var logDescription: String {
+        return """
+               ATTRequest(characteristic: \(characteristic.logDescription),
+               offset: \(offset)
+               id: \((UInt(bitPattern: ObjectIdentifier(self)))))
+               """
+    }
+}
+
 extension Array where Element: Loggable {
     var logDescription: String {
         return "[\(map { $0.logDescription }.joined(separator: ", "))]"

--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -1,10 +1,24 @@
+// The MIT License (MIT)
 //
-//  Logging.swift
-//  RxBluetoothKit
+// Copyright (c) 2017 Polidea
 //
-//  Created by Przemysław Lenart on 23/05/17.
-//  Copyright © 2017 Polidea. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import Foundation
 import CoreBluetooth

--- a/Source/Managers+State.swift
+++ b/Source/Managers+State.swift
@@ -45,7 +45,7 @@ extension BluetoothStateProvider {
     /// - parameter state: `BluetoothState` which should be present during subscription.
     /// - parameter observable: Observable into which potential errors should be merged.
     /// - returns: New observable which merges errors with source observable.
-    func ensure<T>(state: BluetoothState, observable: Observable<T>) -> Observable<T> {
+    func ensure<T>(state: BluetoothState, for observable: Observable<T>) -> Observable<T> {
         let statesObservable = rx_state
             .filter { $0 != state && BluetoothError(state: $0) != nil }
             .map { state -> T in throw BluetoothError(state: state)! }

--- a/Source/Managers+State.swift
+++ b/Source/Managers+State.swift
@@ -1,0 +1,34 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import CoreBluetooth
+import RxSwift
+
+public protocol BluetoothStateProvider {
+    public var state: BluetoothState { get }
+    var stateChanges: Observable<BluetoothState> { get }
+}
+
+extension BluetoothStateProvider {
+    
+}

--- a/Source/Peripheral+Convenience.swift
+++ b/Source/Peripheral+Convenience.swift
@@ -92,7 +92,7 @@ extension Peripheral {
                     }
                     return characteristic.discoverDescriptors()
                         .map {
-                            if let descriptor = $0.filter({ return $0.uuid == identifier.uuid }).first {
+                            if let descriptor = $0.filter({ $0.uuid == identifier.uuid }).first {
                                 return descriptor
                             }
                             throw RxError.noElements
@@ -168,7 +168,7 @@ extension Peripheral {
     /// - returns: Observable which emits `Next` with Characteristic that state was changed. Immediately after `.Complete` is emitted
     public func setNotifyValue(_ enabled: Bool, for identifier: CharacteristicIdentifier)
         -> Single<Characteristic> {
-            return characteristic(with: identifier)
+        return characteristic(with: identifier)
             .flatMap { [weak self] in
                 self?.setNotifyValue(enabled, for: $0) ?? .error(BluetoothError.destroyed)
             }
@@ -181,11 +181,11 @@ extension Peripheral {
     /// This is **infinite** stream of values.
     public func setNotificationAndMonitorUpdates(for identifier: CharacteristicIdentifier)
         -> Observable<Characteristic> {
-            return characteristic(with: identifier)
-                .asObservable()
-                .flatMap { [weak self] in
-                    self?.setNotificationAndMonitorUpdates(for: $0) ?? .error(BluetoothError.destroyed)
-                }
+        return characteristic(with: identifier)
+            .asObservable()
+            .flatMap { [weak self] in
+                self?.setNotificationAndMonitorUpdates(for: $0) ?? .error(BluetoothError.destroyed)
+            }
     }
 
     /// Function that triggers descriptors discovery for characteristic

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -449,7 +449,7 @@ public class Peripheral {
     func ensureValidPeripheralState<T>(for observable: Observable<T>) -> Observable<T> {
         return Observable<T>.absorb(
             manager.ensurePeripheralIsConnected(self),
-            manager.ensure(state: .poweredOn, observable: observable)
+            manager.ensure(state: .poweredOn, for: observable)
         )
     }
 

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -449,7 +449,7 @@ public class Peripheral {
     func ensureValidPeripheralState<T>(for observable: Observable<T>) -> Observable<T> {
         return Observable<T>.absorb(
             manager.ensurePeripheralIsConnected(self),
-            manager.ensure(.poweredOn, observable: observable)
+            manager.ensure(state: .poweredOn, observable: observable)
         )
     }
 

--- a/Source/PeripheralManager.swift
+++ b/Source/PeripheralManager.swift
@@ -1,0 +1,66 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import CoreBluetooth
+import RxSwift
+
+public class PeripheralManager {
+
+    public let peripheralManager: CBPeripheralManager
+
+    private let delegateWrapper = CBPeripheralManagerDelegateWrapper()
+
+    /// IndicatesWhether or not the peripheral is currently advertising data.
+    public var isAdvertising: Bool {
+        return peripheralManager.isAdvertising
+    }
+
+    /// This method does not prompt the user for access.
+    /// You can use it to detect restricted access and simply hide UI instead of prompting for access.
+    /// - returns: The current authorization status for sharing data while backgrounded.
+    public class func authorizationStatus() -> CBPeripheralManagerAuthorizationStatus {
+        return CBPeripheralManager.authorizationStatus()
+    }
+
+    // MARK: Initialization
+
+    /// Creates new `PeripheralManager`
+    /// - parameter peripheralManager: CBPeripheralManager instance used to perform peripheral mode operations
+    /// - parameter queueScheduler: Scheduler on which all serialised operations are executed (such as scans). By default main thread is used.
+    init(peripheralManager: CBPeripheralManager,
+         queueScheduler: SchedulerType = ConcurrentMainScheduler.instance) {
+        self.peripheralManager = peripheralManager
+        peripheralManager.delegate = delegateWrapper
+    }
+
+    /// Creates new `PeripheralManager` instance. By default all operations and events are executed and received on main thread.
+    /// - warning: If you pass background queue to the method make sure to observe results on main thread for UI related code.
+    /// - parameter queue: Queue on which bluetooth callbacks are received. By default main thread is used.
+    /// - parameter options: An optional dictionary containing initialization options for a central manager.
+    /// For more info about it please refer to [Peripheral Manager initialization options](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBPeripheralManager_Class/index.html)
+    public convenience init(queue: DispatchQueue = .main,
+                            options: [String: Any]? = nil) {
+        self.init(peripheralManager: CBPeripheralManager(delegate: nil, queue: queue, options: options),
+                  queueScheduler: ConcurrentDispatchQueueScheduler(queue: queue))
+    }
+}

--- a/Source/PeripheralManager.swift
+++ b/Source/PeripheralManager.swift
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2016 Polidea
+// Copyright (c) 2017 Polidea
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Source/PeripheralManager.swift
+++ b/Source/PeripheralManager.swift
@@ -75,7 +75,12 @@ public class PeripheralManager: BluetoothStateProvider {
     }
 
     public typealias AdvertisingStarted = Void
-    //TODO: Docs
+
+
+    /// <#Description#>
+    ///
+    /// - Parameter advertisementData: Variable which contains the data to be advertised. You should check
+    /// - Returns: Single which emits Void when advertising has started
     public func startAdvertising(_ advertisementData: Variable<[String : Any]?>) -> Single<AdvertisingStarted> {
         let observable = Observable<AdvertisingStarted>.create { [weak self] observer in
             guard let strongSelf = self else {
@@ -108,6 +113,10 @@ public class PeripheralManager: BluetoothStateProvider {
         return ensure(state: .poweredOn, for: observable).asSingle()
     }
 
+    /// <#Description#>
+    ///
+    /// - Parameter advertisementData: <#advertisementData description#>
+    /// - Returns: Single which emits Void when advertising has started
     public func startAdvertising(_ advertisementData: [String : Any]?) -> Single<AdvertisingStarted> {
         return startAdvertising(Variable(advertisementData))
     }

--- a/Source/PeripheralManager.swift
+++ b/Source/PeripheralManager.swift
@@ -63,4 +63,31 @@ public class PeripheralManager {
         self.init(peripheralManager: CBPeripheralManager(delegate: nil, queue: queue, options: options),
                   queueScheduler: ConcurrentDispatchQueueScheduler(queue: queue))
     }
+
+    // MARK: State
+
+    /// Continuous state of `PeripheralManager` instance described by `BluetoothState` which is equivalent to  [CBManagerState](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
+    /// - returns: Observable that emits `Next` immediately after subscribtion with current state of Bluetooth. Later,
+    /// whenever state changes events are emitted. Observable is infinite : doesn't generate `Complete`.
+    public var rx_state: Observable<BluetoothState> {
+        return .deferred { [weak self] in
+            guard let `self` = self else { throw BluetoothError.destroyed }
+            return self.delegateWrapper.rx_didUpdateState.startWith(self.state)
+        }
+    }
+
+    /// Current state of `CentralManager` instance described by `BluetoothState` which is equivalent to [CBManagerState](https://developer.apple.com/reference/corebluetooth/cbmanager/1648600-state).
+    /// - returns: Current state of `PeripheralManager` as `BluetoothState`.
+    public var state: BluetoothState {
+        return BluetoothState(rawValue: peripheralManager.state.rawValue) ?? .unsupported
+    }
+
+    private var isWaitingForAdvertisingCompletion = false
+    public typealias AdvertisingStarted = Void
+    //TODO: Docs
+    public func startAdvertising(_ advertisementData: [String : Any]?) -> Observable<AdvertisingStarted> {
+        return Observable.deferred {
+            
+        }
+    }
 }

--- a/Source/RestoredState.swift
+++ b/Source/RestoredState.swift
@@ -24,19 +24,19 @@ import Foundation
 import CoreBluetooth
 
 #if os(iOS)
-    /// Convenience class which helps reading state of restored BluetoothManager.
+    /// Convenience class which helps reading state of restored CentralManager.
     public struct RestoredState {
 
         /// Restored state dictionary.
         public let restoredStateData: [String: Any]
 
-        public unowned let bluetoothManager: BluetoothManager
+        public unowned let centralManager: CentralManager
         /// Creates restored state information based on CoreBluetooth's dictionary
         /// - parameter restoredStateDictionary: Core Bluetooth's restored state data
-        /// - parameter bluetoothManager: `BluetoothManager` instance of which state has been restored.
-        init(restoredStateDictionary: [String: Any], bluetoothManager: BluetoothManager) {
+        /// - parameter bluetoothManager: `CentralManager` instance of which state has been restored.
+        init(restoredStateDictionary: [String: Any], centralManager: CentralManager) {
             restoredStateData = restoredStateDictionary
-            self.bluetoothManager = bluetoothManager
+            self.centralManager = centralManager
         }
 
         /// Array of `Peripheral` objects which have been restored.
@@ -46,7 +46,7 @@ import CoreBluetooth
             let objects = restoredStateData[CBCentralManagerRestoredStatePeripheralsKey] as? [AnyObject]
             guard let arrayOfAnyObjects = objects else { return [] }
             return arrayOfAnyObjects.flatMap { $0 as? CBPeripheral }
-                .map { Peripheral(manager: bluetoothManager, peripheral: $0) }
+                .map { Peripheral(manager: centralManager, peripheral: $0) }
         }
 
         /// Dictionary that contains all of the peripheral scan options that were being used
@@ -62,7 +62,7 @@ import CoreBluetooth
             let objects = restoredStateData[CBCentralManagerRestoredStateScanServicesKey] as? [AnyObject]
             guard let arrayOfAnyObjects = objects else { return [] }
             return arrayOfAnyObjects.flatMap { $0 as? CBService }
-                .map { Service(peripheral: Peripheral(manager: bluetoothManager,
+                .map { Service(peripheral: Peripheral(manager: centralManager,
                                                       peripheral: $0.peripheral),
                                service: $0) }
         }


### PR DESCRIPTION
In this PR:

I've setup a new class for `CBPeripheralManager` reactive wrapper. I've renamed the current `BluetoothManager` into `CentralManager` which probably makes more sense. 
Implemented sharing of basic things like state management and helper function between two managers.
For `PeripheralManager` full wrappers around the delegates are written.
Also implemented initialisers, basic properties and `startAdvertising` method. It still needs some polishing like documentation. I will add this later today. 

Partially addresses #166 
More of the interface for `PeripheralManager` will be added in subsequent PRs — it's done this way to break it down into smaller pieces, more manageable to review them.

Please let me know what you think!