### PR TITLE
Can accessible to 'internal' protection level

### DIFF
--- a/Source/ScannedPeripheral.swift
+++ b/Source/ScannedPeripheral.swift
@@ -36,7 +36,7 @@ public class ScannedPeripheral {
     /// Scanned peripheral's RSSI value.
     public let rssi: NSNumber
 
-    init(peripheral: Peripheral, advertisementData: AdvertisementData, rssi: NSNumber) {
+    public init(peripheral: Peripheral, advertisementData: AdvertisementData, rssi: NSNumber) {
         self.peripheral = peripheral
         self.advertisementData = advertisementData
         self.rssi = rssi


### PR DESCRIPTION
I use manager.retrievePeripherals, then get Peripheral
I want to modify Peripheral to ScannedPeripheral
so should use the public init on ScannedPeripheral