### PR TITLE
Setup for testing infrastructure

### DIFF
--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -224,7 +224,7 @@ public class BluetoothManager {
     public func connect(_ peripheral: Peripheral, options: [String: Any]? = nil)
         -> Single<Peripheral> {
 
-        let success = delegateWrapper.didConnectPerihperal
+        let success = delegateWrapper.didConnectPeripheral
             .filter { $0 == peripheral.peripheral }
             .take(1)
             .map { _ in return peripheral }
@@ -363,7 +363,7 @@ public class BluetoothManager {
     /// - Parameter peripheral: `Peripheral` which is monitored for connection.
     /// - Returns: Observable which emits next events when `peripheral` was connected.
     public func monitorConnection(for peripheral: Peripheral) -> Observable<Peripheral> {
-        let observable = delegateWrapper.didConnectPerihperal
+        let observable = delegateWrapper.didConnectPeripheral
           .filter { $0 == peripheral.peripheral }
           .map { _ in peripheral }
       return ensure(.poweredOn, observable: observable)

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -45,7 +45,7 @@ public class BluetoothManager {
     /// Implementation of Central Manager
     public let centralManager: CBCentralManager
 
-    private let delegateWrapper = CBCentralManagerDelegateWrapper()
+    private let delegateWrapper: CBCentralManagerDelegateWrapper
 
     /// Queue on which all observables are serialised if needed
     private let subscriptionQueue: SerializedSubscriptionQueue
@@ -61,11 +61,30 @@ public class BluetoothManager {
     /// Creates new `BluetoothManager`
     /// - parameter centralManager: Central instance which is used to perform all of the necessary operations
     /// - parameter queueScheduler: Scheduler on which all serialised operations are executed (such as scans). By default main thread is used.
-    init(centralManager: CBCentralManager,
-         queueScheduler: SchedulerType = ConcurrentMainScheduler.instance) {
+    /// - parameter delegateWrapper: Wrapper on CoreBluetooth's central manager callbacks.
+    internal init(
+      centralManager: CBCentralManager,
+      queueScheduler: SchedulerType = ConcurrentMainScheduler.instance,
+      delegateWrapper: CBCentralManagerDelegateWrapper
+    ) {
         self.centralManager = centralManager
+        self.delegateWrapper = delegateWrapper
         subscriptionQueue = SerializedSubscriptionQueue(scheduler: queueScheduler)
         centralManager.delegate = delegateWrapper
+    }
+
+    /// Creates new `BluetoothManager`
+    /// - parameter centralManager: Central instance which is used to perform all of the necessary operations
+    /// - parameter queueScheduler: Scheduler on which all serialised operations are executed (such as scans). By default main thread is used.
+    convenience init(
+      centralManager: CBCentralManager,
+      queueScheduler: SchedulerType = ConcurrentMainScheduler.instance
+    ) {
+      self.init(
+        centralManager: centralManager,
+        queueScheduler: queueScheduler,
+        delegateWrapper: CBCentralManagerDelegateWrapper()
+      )
     }
 
     /// Creates new `BluetoothManager` instance. By default all operations and events are executed and received on main thread.

--- a/Source/CBCentralManagerDelegateWrapper.swift
+++ b/Source/CBCentralManagerDelegateWrapper.swift
@@ -29,7 +29,7 @@ import RxSwift
     let didUpdateState = PublishSubject<BluetoothState>()
     let willRestoreState = ReplaySubject<[String: Any]>.create(bufferSize: 1)
     let didDiscoverPeripheral = PublishSubject<(CBPeripheral, [String: Any], NSNumber)>()
-    let didConnectPerihperal = PublishSubject<CBPeripheral>()
+    let didConnectPeripheral = PublishSubject<CBPeripheral>()
     let didFailToConnectPeripheral = PublishSubject<(CBPeripheral, Error?)>()
     let didDisconnectPeripheral = PublishSubject<(CBPeripheral, Error?)>()
 
@@ -56,7 +56,7 @@ import RxSwift
     }
 
     @objc func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-        didConnectPerihperal.onNext(peripheral)
+        didConnectPeripheral.onNext(peripheral)
     }
 
     @objc func centralManager(_ central: CBCentralManager,

--- a/Source/CBCentralManagerDelegateWrapper.swift
+++ b/Source/CBCentralManagerDelegateWrapper.swift
@@ -26,12 +26,12 @@ import RxSwift
 
 @objc class CBCentralManagerDelegateWrapper: NSObject, CBCentralManagerDelegate {
 
-    internal let didUpdateState = PublishSubject<BluetoothState>()
-    internal let willRestoreState = ReplaySubject<[String: Any]>.create(bufferSize: 1)
-    internal let didDiscoverPeripheral = PublishSubject<(CBPeripheral, [String: Any], NSNumber)>()
-    internal let didConnectPerihperal = PublishSubject<CBPeripheral>()
-    internal let didFailToConnectPeripheral = PublishSubject<(CBPeripheral, Error?)>()
-    internal let didDisconnectPeripheral = PublishSubject<(CBPeripheral, Error?)>()
+    let didUpdateState = PublishSubject<BluetoothState>()
+    let willRestoreState = ReplaySubject<[String: Any]>.create(bufferSize: 1)
+    let didDiscoverPeripheral = PublishSubject<(CBPeripheral, [String: Any], NSNumber)>()
+    let didConnectPerihperal = PublishSubject<CBPeripheral>()
+    let didFailToConnectPeripheral = PublishSubject<(CBPeripheral, Error?)>()
+    let didDisconnectPeripheral = PublishSubject<(CBPeripheral, Error?)>()
 
     @objc func centralManagerDidUpdateState(_ central: CBCentralManager) {
         guard let bleState = BluetoothState(rawValue: central.state.rawValue) else { return }

--- a/Source/CBCentralManagerDelegateWrapper.swift
+++ b/Source/CBCentralManagerDelegateWrapper.swift
@@ -26,31 +26,12 @@ import RxSwift
 
 @objc class CBCentralManagerDelegateWrapper: NSObject, CBCentralManagerDelegate {
 
-    var rx_didUpdateState: Observable<BluetoothState> {
-        return didUpdateStateSubject
-    }
-    var rx_willRestoreState: Observable<[String: Any]> {
-        return willRestoreStateSubject
-    }
-    var rx_didDiscoverPeripheral: Observable<(CBPeripheral, [String: Any], NSNumber)> {
-        return didDiscoverPeripheralSubject
-    }
-    var rx_didConnectPeripheral: Observable<CBPeripheral> {
-        return didConnectPerihperalSubject
-    }
-    var rx_didFailToConnectPeripheral: Observable<(CBPeripheral, Error?)> {
-        return didFailToConnectPeripheralSubject
-    }
-    var rx_didDisconnectPeripheral: Observable<(CBPeripheral, Error?)> {
-        return didDisconnectPeripheral
-    }
-
-    private let didUpdateStateSubject = PublishSubject<BluetoothState>()
-    private let willRestoreStateSubject = ReplaySubject<[String: Any]>.create(bufferSize: 1)
-    private let didDiscoverPeripheralSubject = PublishSubject<(CBPeripheral, [String: Any], NSNumber)>()
-    private let didConnectPerihperalSubject = PublishSubject<CBPeripheral>()
-    private let didFailToConnectPeripheralSubject = PublishSubject<(CBPeripheral, Error?)>()
-    private let didDisconnectPeripheral = PublishSubject<(CBPeripheral, Error?)>()
+    internal let didUpdateStateSubject = PublishSubject<BluetoothState>()
+    internal let willRestoreStateSubject = ReplaySubject<[String: Any]>.create(bufferSize: 1)
+    internal let didDiscoverPeripheralSubject = PublishSubject<(CBPeripheral, [String: Any], NSNumber)>()
+    internal let didConnectPerihperalSubject = PublishSubject<CBPeripheral>()
+    internal let didFailToConnectPeripheralSubject = PublishSubject<(CBPeripheral, Error?)>()
+    internal let didDisconnectPeripheral = PublishSubject<(CBPeripheral, Error?)>()
 
     @objc func centralManagerDidUpdateState(_ central: CBCentralManager) {
         guard let bleState = BluetoothState(rawValue: central.state.rawValue) else { return }

--- a/Source/CBCentralManagerDelegateWrapper.swift
+++ b/Source/CBCentralManagerDelegateWrapper.swift
@@ -26,22 +26,22 @@ import RxSwift
 
 @objc class CBCentralManagerDelegateWrapper: NSObject, CBCentralManagerDelegate {
 
-    internal let didUpdateStateSubject = PublishSubject<BluetoothState>()
-    internal let willRestoreStateSubject = ReplaySubject<[String: Any]>.create(bufferSize: 1)
-    internal let didDiscoverPeripheralSubject = PublishSubject<(CBPeripheral, [String: Any], NSNumber)>()
-    internal let didConnectPerihperalSubject = PublishSubject<CBPeripheral>()
-    internal let didFailToConnectPeripheralSubject = PublishSubject<(CBPeripheral, Error?)>()
+    internal let didUpdateState = PublishSubject<BluetoothState>()
+    internal let willRestoreState = ReplaySubject<[String: Any]>.create(bufferSize: 1)
+    internal let didDiscoverPeripheral = PublishSubject<(CBPeripheral, [String: Any], NSNumber)>()
+    internal let didConnectPerihperal = PublishSubject<CBPeripheral>()
+    internal let didFailToConnectPeripheral = PublishSubject<(CBPeripheral, Error?)>()
     internal let didDisconnectPeripheral = PublishSubject<(CBPeripheral, Error?)>()
 
     @objc func centralManagerDidUpdateState(_ central: CBCentralManager) {
         guard let bleState = BluetoothState(rawValue: central.state.rawValue) else { return }
         RxBluetoothKitLog.d("\(central.logDescription) didUpdateState(state: \(bleState.logDescription))")
-        didUpdateStateSubject.onNext(bleState)
+        didUpdateState.onNext(bleState)
     }
 
     @objc func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
         RxBluetoothKitLog.d("\(central.logDescription) willRestoreState(restoredState: \(dict))")
-        willRestoreStateSubject.onNext(dict)
+        willRestoreState.onNext(dict)
     }
 
     @objc func centralManager(_ central: CBCentralManager,
@@ -52,11 +52,11 @@ import RxSwift
             \(central.logDescription) didDiscover(peripheral: \(peripheral.logDescription),
             rssi: \(rssi))
             """)
-        didDiscoverPeripheralSubject.onNext((peripheral, advertisementData, rssi))
+        didDiscoverPeripheral.onNext((peripheral, advertisementData, rssi))
     }
 
     @objc func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-        didConnectPerihperalSubject.onNext(peripheral)
+        didConnectPerihperal.onNext(peripheral)
     }
 
     @objc func centralManager(_ central: CBCentralManager,
@@ -66,7 +66,7 @@ import RxSwift
             \(central.logDescription) didFailToConnect(to: \(peripheral.logDescription),
             error: \(String(describing: error)))
             """)
-        didFailToConnectPeripheralSubject.onNext((peripheral, error))
+        didFailToConnectPeripheral.onNext((peripheral, error))
     }
 
     @objc func centralManager(_ central: CBCentralManager,

--- a/Source/CBPeripheralDelegateWrapper.swift
+++ b/Source/CBPeripheralDelegateWrapper.swift
@@ -26,28 +26,28 @@ import RxSwift
 
 @objc class CBPeripheralDelegateWrapper: NSObject, CBPeripheralDelegate {
 
-    internal let peripheralDidUpdateNameSubject = PublishSubject<String?>()
-    internal let peripheralDidModifyServicesSubject = PublishSubject<([CBService])>()
-    internal let peripheralDidReadRSSISubject = PublishSubject<(Int, Error?)>()
-    internal let peripheralDidDiscoverServicesSubject = PublishSubject<([CBService]?, Error?)>()
-    internal let peripheralDidDiscoverIncludedServicesForServiceSubject = PublishSubject<(CBService, Error?)>()
-    internal let peripheralDidDiscoverCharacteristicsForServiceSubject = PublishSubject<(CBService, Error?)>()
-    internal let peripheralDidUpdateValueForCharacteristicSubject = PublishSubject<(CBCharacteristic, Error?)>()
-    internal let peripheralDidWriteValueForCharacteristicSubject = PublishSubject<(CBCharacteristic, Error?)>()
-    internal let peripheralDidUpdateNotificationStateForCharacteristicSubject =
+    internal let peripheralDidUpdateName = PublishSubject<String?>()
+    internal let peripheralDidModifyServices = PublishSubject<([CBService])>()
+    internal let peripheralDidReadRSSI = PublishSubject<(Int, Error?)>()
+    internal let peripheralDidDiscoverServices = PublishSubject<([CBService]?, Error?)>()
+    internal let peripheralDidDiscoverIncludedServicesForService = PublishSubject<(CBService, Error?)>()
+    internal let peripheralDidDiscoverCharacteristicsForService = PublishSubject<(CBService, Error?)>()
+    internal let peripheralDidUpdateValueForCharacteristic = PublishSubject<(CBCharacteristic, Error?)>()
+    internal let peripheralDidWriteValueForCharacteristic = PublishSubject<(CBCharacteristic, Error?)>()
+    internal let peripheralDidUpdateNotificationStateForCharacteristic =
         PublishSubject<(CBCharacteristic, Error?)>()
-    internal let peripheralDidDiscoverDescriptorsForCharacteristicSubject =
+    internal let peripheralDidDiscoverDescriptorsForCharacteristic =
         PublishSubject<(CBCharacteristic, Error?)>()
-    internal let peripheralDidUpdateValueForDescriptorSubject = PublishSubject<(CBDescriptor, Error?)>()
-    internal let peripheralDidWriteValueForDescriptorSubject = PublishSubject<(CBDescriptor, Error?)>()
-    internal let peripheralIsReadyToSendWriteWithoutResponseSubject = PublishSubject<Void>()
-    internal let peripheralDidOpenL2CAPChannelSubject = PublishSubject<(Any?, Error?)>()
+    internal let peripheralDidUpdateValueForDescriptor = PublishSubject<(CBDescriptor, Error?)>()
+    internal let peripheralDidWriteValueForDescriptor = PublishSubject<(CBDescriptor, Error?)>()
+    internal let peripheralIsReadyToSendWriteWithoutResponse = PublishSubject<Void>()
+    internal let peripheralDidOpenL2CAPChannel = PublishSubject<(Any?, Error?)>()
 
     @objc func peripheralDidUpdateName(_ peripheral: CBPeripheral) {
         RxBluetoothKitLog.d("""
             \(peripheral.logDescription) didUpdateName(name: \(String(describing: peripheral.name)))
             """)
-        peripheralDidUpdateNameSubject.onNext(peripheral.name)
+        peripheralDidUpdateName.onNext(peripheral.name)
     }
 
     @objc func peripheral(_ peripheral: CBPeripheral, didModifyServices invalidatedServices: [CBService]) {
@@ -55,7 +55,7 @@ import RxSwift
             \(peripheral.logDescription) didModifyServices(services:
             [\(invalidatedServices.logDescription))]
             """)
-        peripheralDidModifyServicesSubject.onNext(invalidatedServices)
+        peripheralDidModifyServices.onNext(invalidatedServices)
     }
 
     @objc func peripheral(_ peripheral: CBPeripheral, didReadRSSI rssi: NSNumber, error: Error?) {
@@ -63,7 +63,7 @@ import RxSwift
             \(peripheral.logDescription) didReadRSSI(rssi: \(rssi),
             error: \(String(describing: error)))
             """)
-        peripheralDidReadRSSISubject.onNext((rssi.intValue, error))
+        peripheralDidReadRSSI.onNext((rssi.intValue, error))
     }
 
     @objc func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
@@ -72,7 +72,7 @@ import RxSwift
             : \(String(describing: peripheral.services?.logDescription)),
             error: \(String(describing: error)))
             """)
-        peripheralDidDiscoverServicesSubject.onNext((peripheral.services, error))
+        peripheralDidDiscoverServices.onNext((peripheral.services, error))
     }
 
     @objc func peripheral(_ peripheral: CBPeripheral,
@@ -84,7 +84,7 @@ import RxSwift
             \(String(describing: service.includedServices?.logDescription)),
             error: \(String(describing: error)))
             """)
-        peripheralDidDiscoverIncludedServicesForServiceSubject.onNext((service, error))
+        peripheralDidDiscoverIncludedServicesForService.onNext((service, error))
     }
 
     @objc func peripheral(_ peripheral: CBPeripheral,
@@ -96,7 +96,7 @@ import RxSwift
             \(String(describing: service.characteristics?.logDescription)),
             error: \(String(describing: error)))
             """)
-        peripheralDidDiscoverCharacteristicsForServiceSubject.onNext((service, error))
+        peripheralDidDiscoverCharacteristicsForService.onNext((service, error))
     }
 
     @objc func peripheral(_ peripheral: CBPeripheral,
@@ -107,7 +107,7 @@ import RxSwift
             value: \(String(describing: characteristic.value?.logDescription)),
             error: \(String(describing: error)))
             """)
-        peripheralDidUpdateValueForCharacteristicSubject
+        peripheralDidUpdateValueForCharacteristic
             .onNext((characteristic, error))
     }
 
@@ -119,7 +119,7 @@ import RxSwift
             value: \(String(describing: characteristic.value?.logDescription)),
             error: \(String(describing: error)))
             """)
-        peripheralDidWriteValueForCharacteristicSubject
+        peripheralDidWriteValueForCharacteristic
             .onNext((characteristic, error))
     }
 
@@ -131,7 +131,7 @@ import RxSwift
             for:\(characteristic.logDescription), isNotifying: \(characteristic.isNotifying),
             error: \(String(describing: error)))
             """)
-        peripheralDidUpdateNotificationStateForCharacteristicSubject
+        peripheralDidUpdateNotificationStateForCharacteristic
             .onNext((characteristic, error))
     }
 
@@ -144,7 +144,7 @@ import RxSwift
             \(String(describing: characteristic.descriptors?.logDescription)),
             error: \(String(describing: error)))
             """)
-        peripheralDidDiscoverDescriptorsForCharacteristicSubject
+        peripheralDidDiscoverDescriptorsForCharacteristic
             .onNext((characteristic, error))
     }
 
@@ -155,7 +155,7 @@ import RxSwift
             \(peripheral.logDescription) didUpdateValueFor(for:\(descriptor.logDescription),
             value: \(String(describing: descriptor.value)), error: \(String(describing: error)))
             """)
-        peripheralDidUpdateValueForDescriptorSubject.onNext((descriptor, error))
+        peripheralDidUpdateValueForDescriptor.onNext((descriptor, error))
     }
 
     @objc func peripheral(_ peripheral: CBPeripheral,
@@ -165,14 +165,14 @@ import RxSwift
             \(peripheral.logDescription) didWriteValueFor(for:\(descriptor.logDescription),
             error: \(String(describing: error)))
             """)
-        peripheralDidWriteValueForDescriptorSubject.onNext((descriptor, error))
+        peripheralDidWriteValueForDescriptor.onNext((descriptor, error))
     }
 
     func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
         RxBluetoothKitLog.d("""
             \(peripheral.logDescription) peripheralIsReady(toSendWriteWithoutResponse)
             """)
-        peripheralIsReadyToSendWriteWithoutResponseSubject.onNext(())
+        peripheralIsReadyToSendWriteWithoutResponse.onNext(())
     }
 
     @available(OSX 10.13, iOS 11, *)
@@ -181,6 +181,6 @@ import RxSwift
             \(peripheral.logDescription) didOpenL2CAPChannel(for:\(peripheral.logDescription),
             error: \(String(describing: error)))
             """)
-        peripheralDidOpenL2CAPChannelSubject.onNext((channel, error))
+        peripheralDidOpenL2CAPChannel.onNext((channel, error))
     }
 }

--- a/Source/CBPeripheralDelegateWrapper.swift
+++ b/Source/CBPeripheralDelegateWrapper.swift
@@ -26,22 +26,22 @@ import RxSwift
 
 @objc class CBPeripheralDelegateWrapper: NSObject, CBPeripheralDelegate {
 
-    internal let peripheralDidUpdateName = PublishSubject<String?>()
-    internal let peripheralDidModifyServices = PublishSubject<([CBService])>()
-    internal let peripheralDidReadRSSI = PublishSubject<(Int, Error?)>()
-    internal let peripheralDidDiscoverServices = PublishSubject<([CBService]?, Error?)>()
-    internal let peripheralDidDiscoverIncludedServicesForService = PublishSubject<(CBService, Error?)>()
-    internal let peripheralDidDiscoverCharacteristicsForService = PublishSubject<(CBService, Error?)>()
-    internal let peripheralDidUpdateValueForCharacteristic = PublishSubject<(CBCharacteristic, Error?)>()
-    internal let peripheralDidWriteValueForCharacteristic = PublishSubject<(CBCharacteristic, Error?)>()
-    internal let peripheralDidUpdateNotificationStateForCharacteristic =
+    let peripheralDidUpdateName = PublishSubject<String?>()
+    let peripheralDidModifyServices = PublishSubject<([CBService])>()
+    let peripheralDidReadRSSI = PublishSubject<(Int, Error?)>()
+    let peripheralDidDiscoverServices = PublishSubject<([CBService]?, Error?)>()
+    let peripheralDidDiscoverIncludedServicesForService = PublishSubject<(CBService, Error?)>()
+    let peripheralDidDiscoverCharacteristicsForService = PublishSubject<(CBService, Error?)>()
+    let peripheralDidUpdateValueForCharacteristic = PublishSubject<(CBCharacteristic, Error?)>()
+    let peripheralDidWriteValueForCharacteristic = PublishSubject<(CBCharacteristic, Error?)>()
+    let peripheralDidUpdateNotificationStateForCharacteristic =
         PublishSubject<(CBCharacteristic, Error?)>()
-    internal let peripheralDidDiscoverDescriptorsForCharacteristic =
+    let peripheralDidDiscoverDescriptorsForCharacteristic =
         PublishSubject<(CBCharacteristic, Error?)>()
-    internal let peripheralDidUpdateValueForDescriptor = PublishSubject<(CBDescriptor, Error?)>()
-    internal let peripheralDidWriteValueForDescriptor = PublishSubject<(CBDescriptor, Error?)>()
-    internal let peripheralIsReadyToSendWriteWithoutResponse = PublishSubject<Void>()
-    internal let peripheralDidOpenL2CAPChannel = PublishSubject<(Any?, Error?)>()
+    let peripheralDidUpdateValueForDescriptor = PublishSubject<(CBDescriptor, Error?)>()
+    let peripheralDidWriteValueForDescriptor = PublishSubject<(CBDescriptor, Error?)>()
+    let peripheralIsReadyToSendWriteWithoutResponse = PublishSubject<Void>()
+    let peripheralDidOpenL2CAPChannel = PublishSubject<(Any?, Error?)>()
 
     @objc func peripheralDidUpdateName(_ peripheral: CBPeripheral) {
         RxBluetoothKitLog.d("""

--- a/Source/CBPeripheralDelegateWrapper.swift
+++ b/Source/CBPeripheralDelegateWrapper.swift
@@ -26,60 +26,22 @@ import RxSwift
 
 @objc class CBPeripheralDelegateWrapper: NSObject, CBPeripheralDelegate {
 
-    var rx_didUpdateName: Observable<String?> { return peripheralDidUpdateNameSubject }
-    var rx_didModifyServices: Observable<([CBService])> { return peripheralDidModifyServicesSubject }
-    var rx_didReadRSSI: Observable<(Int, Error?)> { return peripheralDidReadRSSISubject }
-    var rx_didDiscoverServices: Observable<([CBService]?, Error?)> { return peripheralDidDiscoverServicesSubject }
-    var rx_didDiscoverIncludedServicesForService: Observable<(CBService, Error?)> {
-        return peripheralDidDiscoverIncludedServicesForServiceSubject
-    }
-    var rx_didDiscoverCharacteristicsForService: Observable<(CBService, Error?)> {
-        return peripheralDidDiscoverCharacteristicsForServiceSubject
-    }
-    var rx_didUpdateValueForCharacteristic: Observable<(CBCharacteristic, Error?)> {
-        return peripheralDidUpdateValueForCharacteristicSubject
-    }
-    var rx_didWriteValueForCharacteristic: Observable<(CBCharacteristic, Error?)> {
-        return peripheralDidWriteValueForCharacteristicSubject
-    }
-    var rx_didUpdateNotificationStateForCharacteristic: Observable<(CBCharacteristic, Error?)> {
-        return peripheralDidUpdateNotificationStateForCharacteristicSubject
-    }
-    var rx_didDiscoverDescriptorsForCharacteristic: Observable<(CBCharacteristic, Error?)> {
-        return peripheralDidDiscoverDescriptorsForCharacteristicSubject
-    }
-    var rx_didUpdateValueForDescriptor: Observable<(CBDescriptor, Error?)> {
-        return peripheralDidUpdateValueForDescriptorSubject
-    }
-    var rx_didWriteValueForDescriptor: Observable<(CBDescriptor, Error?)> {
-        return peripheralDidWriteValueForDescriptorSubject
-    }
-    var rx_peripheralReadyToSendWriteWithoutResponse: Observable<Void> {
-        return peripheralIsReadyToSendWriteWithoutResponseSubject
-    }
-    
-    @available(OSX 10.13, iOS 11, *)
-    var rx_didOpenL2CAPChannel: Observable<(CBL2CAPChannel?, Error?)> {
-        return peripheralDidOpenL2CAPChannelSubject
-            .map {($0.0 as? CBL2CAPChannel, $0.1)}
-    }
-
-    private let peripheralDidUpdateNameSubject = PublishSubject<String?>()
-    private let peripheralDidModifyServicesSubject = PublishSubject<([CBService])>()
-    private let peripheralDidReadRSSISubject = PublishSubject<(Int, Error?)>()
-    private let peripheralDidDiscoverServicesSubject = PublishSubject<([CBService]?, Error?)>()
-    private let peripheralDidDiscoverIncludedServicesForServiceSubject = PublishSubject<(CBService, Error?)>()
-    private let peripheralDidDiscoverCharacteristicsForServiceSubject = PublishSubject<(CBService, Error?)>()
-    private let peripheralDidUpdateValueForCharacteristicSubject = PublishSubject<(CBCharacteristic, Error?)>()
-    private let peripheralDidWriteValueForCharacteristicSubject = PublishSubject<(CBCharacteristic, Error?)>()
-    private let peripheralDidUpdateNotificationStateForCharacteristicSubject =
+    internal let peripheralDidUpdateNameSubject = PublishSubject<String?>()
+    internal let peripheralDidModifyServicesSubject = PublishSubject<([CBService])>()
+    internal let peripheralDidReadRSSISubject = PublishSubject<(Int, Error?)>()
+    internal let peripheralDidDiscoverServicesSubject = PublishSubject<([CBService]?, Error?)>()
+    internal let peripheralDidDiscoverIncludedServicesForServiceSubject = PublishSubject<(CBService, Error?)>()
+    internal let peripheralDidDiscoverCharacteristicsForServiceSubject = PublishSubject<(CBService, Error?)>()
+    internal let peripheralDidUpdateValueForCharacteristicSubject = PublishSubject<(CBCharacteristic, Error?)>()
+    internal let peripheralDidWriteValueForCharacteristicSubject = PublishSubject<(CBCharacteristic, Error?)>()
+    internal let peripheralDidUpdateNotificationStateForCharacteristicSubject =
         PublishSubject<(CBCharacteristic, Error?)>()
-    private let peripheralDidDiscoverDescriptorsForCharacteristicSubject =
+    internal let peripheralDidDiscoverDescriptorsForCharacteristicSubject =
         PublishSubject<(CBCharacteristic, Error?)>()
-    private let peripheralDidUpdateValueForDescriptorSubject = PublishSubject<(CBDescriptor, Error?)>()
-    private let peripheralDidWriteValueForDescriptorSubject = PublishSubject<(CBDescriptor, Error?)>()
-    private let peripheralIsReadyToSendWriteWithoutResponseSubject = PublishSubject<Void>()
-    private let peripheralDidOpenL2CAPChannelSubject = PublishSubject<(Any?, Error?)>()
+    internal let peripheralDidUpdateValueForDescriptorSubject = PublishSubject<(CBDescriptor, Error?)>()
+    internal let peripheralDidWriteValueForDescriptorSubject = PublishSubject<(CBDescriptor, Error?)>()
+    internal let peripheralIsReadyToSendWriteWithoutResponseSubject = PublishSubject<Void>()
+    internal let peripheralDidOpenL2CAPChannelSubject = PublishSubject<(Any?, Error?)>()
 
     @objc func peripheralDidUpdateName(_ peripheral: CBPeripheral) {
         RxBluetoothKitLog.d("""
@@ -212,7 +174,7 @@ import RxSwift
             """)
         peripheralIsReadyToSendWriteWithoutResponseSubject.onNext(())
     }
-    
+
     @available(OSX 10.13, iOS 11, *)
     @objc func peripheral(_ peripheral: CBPeripheral, didOpen channel: CBL2CAPChannel?, error: Error?) {
         RxBluetoothKitLog.d("""

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -31,15 +31,27 @@ import CoreBluetooth
 public class Peripheral {
     public let manager: BluetoothManager
 
-    init(manager: BluetoothManager, peripheral: CBPeripheral) {
-        self.manager = manager
-        self.peripheral = peripheral
-        peripheral.delegate = delegateWrapper
+    /// Creates new `Peripheral`
+    /// - parameter manager: Central instance which is used to perform all of the necessary operations.
+    /// - parameter peripheral: Instance representing specific peripheral allowing to perform operations on it.
+    /// - parameter delegateWrapper: Wrapper on CoreBluetooth's peripheral callbacks.
+    internal init(manager: BluetoothManager, peripheral: CBPeripheral, delegateWrapper: CBPeripheralDelegateWrapper) {
+      self.manager = manager
+      self.peripheral = peripheral
+      self.delegateWrapper = delegateWrapper
+      peripheral.delegate = delegateWrapper
+    }
+
+    /// Creates new `Peripheral`
+    /// - parameter manager: Central instance which is used to perform all of the necessary operations.
+    /// - parameter peripheral: Instance representing specific peripheral allowing to perform operations on it.
+    convenience init(manager: BluetoothManager, peripheral: CBPeripheral) {
+      self.init(manager: manager, peripheral: peripheral, delegateWrapper: CBPeripheralDelegateWrapper())
     }
 
     /// Implementation of peripheral
     public let peripheral: CBPeripheral
-    private let delegateWrapper = CBPeripheralDelegateWrapper()
+    private let delegateWrapper: CBPeripheralDelegateWrapper
 
     ///  Continuous value indicating if peripheral is in connected state. This is continuous value, which first emits `.Next` with current state, and later whenever state change occurs
     public var rx_isConnected: Observable<Bool> {

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -412,7 +412,7 @@ public class Peripheral {
     /// It's **infinite** stream, so `.Complete` is never called.
     public func monitorWrite(for descriptor: Descriptor) -> Observable<Descriptor> {
         let observable = delegateWrapper
-            .peripheralDidWriteValueForCharacteristicSubject
+            .peripheralDidWriteValueForDescriptorSubject
             .filter { $0.0 == descriptor.descriptor }
             .map { (_, error) -> Descriptor in
                 if let error = error {
@@ -428,7 +428,8 @@ public class Peripheral {
     /// - Returns: Observable that emits `Next` with `Descriptor` instance every time when value has changed.
     /// It's **infinite** stream, so `.Complete` is never called.
     public func monitorValueUpdate(for descriptor: Descriptor) -> Observable<Descriptor> {
-        let observable = delegateWrapper.peripheralDidUpdateValueForCharacteristicSubject
+        let observable = delegateWrapper
+            .peripheralDidUpdateValueForDescriptorSubject
             .filter { $0.0 == descriptor.descriptor }
             .map { (_, error) -> Descriptor in
                 if let error = error {


### PR DESCRIPTION
As a part of #168 this PR makes initial setup for testing infrastructure to allow create fakes of `BluetoothManager` and `Peripheral`.

Internal inits with delegate wrappers as a parameter will allow to generate and inject fake classes to make integration tests.