### PR TITLE
Simplify scanning implementation

### DIFF
--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -100,11 +100,10 @@ public class BluetoothManager {
     /// ```
     ///
     /// If different scan is currently in progress and peripherals needed by a user can be discovered by it, new scan is
-    /// shared. Otherwise scan is queued on thread specified in `init(centralManager:queueScheduler:)` and will be executed
-    /// when other scans finished with complete/error event or were unsubscribed.
-    /// As a result you will receive `ScannedPeripheral` which contains `Peripheral` object, `AdvertisementData` and
-    /// peripheral's RSSI registered during discovery. You can then `connectToPeripheral(_:options:)` and do other
-    /// operations.
+    /// shared. Otherwise scan is queued and will be executed when other scans finished with complete/error event or
+    /// were unsubscribed. As a result you will receive `ScannedPeripheral` which contains `Peripheral` object,
+    /// `AdvertisementData` and peripheral's RSSI registered during discovery. You can then
+    /// `connectToPeripheral(_:options:)` and do other operations.
     /// - seealso: `Peripheral`
     ///
     /// - parameter serviceUUIDs: Services of peripherals to search for. Nil value will accept all peripherals.

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -47,7 +47,7 @@ public class BluetoothManager {
     private let centralManager: RxCentralManagerType
 
     /// Queue on which all observables are serialised if needed
-    private let subscriptionQueue: SerializedSubscriptionQueue
+    private let subscriptionQueue = SerializedSubscriptionQueue()
 
     /// Lock which should be used before accessing any internal structures
     private let lock = NSLock()
@@ -70,11 +70,8 @@ public class BluetoothManager {
     /// Creates new `BluetoothManager` instance with specified implementation of `RxCentralManagerType` protocol which will be
     /// used by this class. Most of a time `RxCBCentralManager` should be chosen by the user.
     /// - parameter centralManager: Implementation of `RxCentralManagerType` protocol used by this class.
-    /// - parameter queueScheduler: Scheduler on which all serialised operations are executed (such as scans). By default main thread is used.
-    init(centralManager: RxCentralManagerType,
-         queueScheduler: SchedulerType = ConcurrentMainScheduler.instance) {
+    init(centralManager: RxCentralManagerType) {
         self.centralManager = centralManager
-        subscriptionQueue = SerializedSubscriptionQueue(scheduler: queueScheduler)
     }
 
     /// Creates new `BluetoothManager` instance. By default all operations and events are executed and received on main thread.
@@ -84,8 +81,7 @@ public class BluetoothManager {
     /// For more info about it please refer to [Central Manager initialization options](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/index.html)
     public convenience init(queue: DispatchQueue = .main,
                             options: [String: AnyObject]? = nil) {
-        self.init(centralManager: RxCBCentralManager(queue: queue, options: options),
-                  queueScheduler: ConcurrentDispatchQueueScheduler(queue: queue))
+        self.init(centralManager: RxCBCentralManager(queue: queue, options: options))
     }
 
     // MARK: Scanning
@@ -116,71 +112,71 @@ public class BluetoothManager {
     /// - returns: Infinite stream of scanned peripherals.
     public func scanForPeripherals(withServices serviceUUIDs: [CBUUID]?, options: [String: Any]? = nil)
         -> Observable<ScannedPeripheral> {
-        return .deferred { [weak self] in
-            guard let strongSelf = self else { throw BluetoothError.destroyed }
-            let observable: Observable<ScannedPeripheral> = { [weak self] () -> Observable<ScannedPeripheral> in
-                guard let strongSelf = self else { return .error(BluetoothError.destroyed) }
-                // If it's possible use existing scan - take if from the queue
-                strongSelf.lock.lock(); defer { strongSelf.lock.unlock() }
-                if let elem = strongSelf.scanQueue.first(where: { $0.shouldAccept(serviceUUIDs) }) {
-                    guard let serviceUUIDs = serviceUUIDs else {
-                        return elem.observable
+            return .deferred { [weak self] in
+                guard let strongSelf = self else { throw BluetoothError.destroyed }
+                let observable: Observable<ScannedPeripheral> = { [weak self] () -> Observable<ScannedPeripheral> in
+                    guard let strongSelf = self else { return .error(BluetoothError.destroyed) }
+                    // If it's possible use existing scan - take if from the queue
+                    strongSelf.lock.lock(); defer { strongSelf.lock.unlock() }
+                    if let elem = strongSelf.scanQueue.first(where: { $0.shouldAccept(serviceUUIDs) }) {
+                        guard let serviceUUIDs = serviceUUIDs else {
+                            return elem.observable
+                        }
+
+                        // When binding to existing scan we need to make sure that services are
+                        // filtered properly
+                        return elem.observable.filter { scannedPeripheral in
+                            if let services = scannedPeripheral.advertisementData.serviceUUIDs {
+                                return Set(services).isSuperset(of: Set(serviceUUIDs))
+                            }
+                            return false
+                        }
                     }
 
-                    // When binding to existing scan we need to make sure that services are
-                    // filtered properly
-                    return elem.observable.filter { scannedPeripheral in
-                        if let services = scannedPeripheral.advertisementData.serviceUUIDs {
-                            return Set(services).isSuperset(of: Set(serviceUUIDs))
-                        }
-                        return false
-                    }
-                }
+                    let scanOperationBox = WeakBox<ScanOperation>()
 
-                let scanOperationBox = WeakBox<ScanOperation>()
+                    // Create new scan which will be processed in a queue
+                    let operation = Observable.create { [weak self] (element: AnyObserver<ScannedPeripheral>) -> Disposable in
+                        guard let strongSelf = self else { return Disposables.create() }
+                        // Observable which will emit next element, when peripheral is discovered.
+                        let disposable = strongSelf.centralManager.rx_didDiscoverPeripheral
+                            .flatMap { [weak self] (peripheral, advertisment, rssi) -> Observable<ScannedPeripheral> in
+                                guard let strongSelf = self else { throw BluetoothError.destroyed }
+                                let peripheral = Peripheral(manager: strongSelf, peripheral: peripheral)
+                                let advertismentData = AdvertisementData(advertisementData: advertisment)
+                                return .just(ScannedPeripheral(peripheral: peripheral,
+                                                               advertisementData: advertismentData, rssi: rssi))
+                            }
+                            .subscribe(element)
 
-                // Create new scan which will be processed in a queue
-                let operation = Observable.create { [weak self] (element: AnyObserver<ScannedPeripheral>) -> Disposable in
-                    guard let strongSelf = self else { return Disposables.create() }
-                    // Observable which will emit next element, when peripheral is discovered.
-                    let disposable = strongSelf.centralManager.rx_didDiscoverPeripheral
-                        .flatMap { [weak self] (peripheral, advertisment, rssi) -> Observable<ScannedPeripheral> in
-                            guard let strongSelf = self else { throw BluetoothError.destroyed }
-                            let peripheral = Peripheral(manager: strongSelf, peripheral: peripheral)
-                            let advertismentData = AdvertisementData(advertisementData: advertisment)
-                            return .just(ScannedPeripheral(peripheral: peripheral,
-                                                           advertisementData: advertismentData, rssi: rssi))
-                        }
-                        .subscribe(element)
+                        // Start scanning for devices
+                        strongSelf.centralManager.scanForPeripherals(withServices: serviceUUIDs, options: options)
 
-                    // Start scanning for devices
-                    strongSelf.centralManager.scanForPeripherals(withServices: serviceUUIDs, options: options)
-
-                    return Disposables.create { [weak self] in
-                        guard let strongSelf = self else { return }
-                        // When disposed, stop all scans, and remove scanning operation from queue
-                        strongSelf.centralManager.stopScan()
-                        disposable.dispose()
-                        do { strongSelf.lock.lock(); defer { strongSelf.lock.unlock() }
-                            if let index = strongSelf.scanQueue.index(where: { $0 == scanOperationBox.value! }) {
-                                strongSelf.scanQueue.remove(at: index)
+                        return Disposables.create { [weak self] in
+                            guard let strongSelf = self else { return }
+                            // When disposed, stop all scans, and remove scanning operation from queue
+                            strongSelf.centralManager.stopScan()
+                            disposable.dispose()
+                            do { strongSelf.lock.lock(); defer { strongSelf.lock.unlock() }
+                                if let index = strongSelf.scanQueue.index(where: { $0 == scanOperationBox.value! }) {
+                                    strongSelf.scanQueue.remove(at: index)
+                                }
                             }
                         }
-                    }
-                }
-                .queueSubscribe(on: strongSelf.subscriptionQueue)
-                .publish()
-                .refCount()
+                        }
+                        .queueSubscribe(on: strongSelf.subscriptionQueue)
+                        .publish()
+                        .refCount()
 
-                let scanOperation = ScanOperation(uuids: serviceUUIDs, observable: operation)
-                strongSelf.scanQueue.append(scanOperation)
+                    let scanOperation = ScanOperation(uuids: serviceUUIDs, observable: operation)
+                    strongSelf.scanQueue.append(scanOperation)
 
-                scanOperationBox.value = scanOperation
-                return operation
-            }()
-            // Allow scanning as long as bluetooth is powered on
-            return strongSelf.ensure(.poweredOn, observable: observable)
-        }
+                    scanOperationBox.value = scanOperation
+                    return operation
+                    }()
+                // Allow scanning as long as bluetooth is powered on
+                return strongSelf.ensure(.poweredOn, observable: observable)
+            }
     }
 
     // MARK: State
@@ -214,48 +210,48 @@ public class BluetoothManager {
     public func connect(_ peripheral: Peripheral, options: [String: Any]? = nil)
         -> Observable<Peripheral> {
 
-        let success = centralManager.rx_didConnectPeripheral
-            .filter { $0 == peripheral.peripheral }
-            .take(1)
-            .map { _ in return peripheral }
+            let success = centralManager.rx_didConnectPeripheral
+                .filter { $0 == peripheral.peripheral }
+                .take(1)
+                .map { _ in return peripheral }
 
-        let error = centralManager.rx_didFailToConnectPeripheral
-            .filter { $0.0 == peripheral.peripheral }
-            .take(1)
-            .map { (peripheral, error) -> Peripheral in
-                throw BluetoothError.peripheralConnectionFailed(Peripheral(manager: self, peripheral: peripheral), error)
+            let error = centralManager.rx_didFailToConnectPeripheral
+                .filter { $0.0 == peripheral.peripheral }
+                .take(1)
+                .map { (peripheral, error) -> Peripheral in
+                    throw BluetoothError.peripheralConnectionFailed(Peripheral(manager: self, peripheral: peripheral), error)
             }
 
-        let observable = Observable<Peripheral>.create { [weak self] observer in
-            guard let strongSelf = self else {
-                observer.onError(BluetoothError.destroyed)
-                return Disposables.create()
-            }
-            if let error = BluetoothError(state: strongSelf.centralManager.state) {
-                observer.onError(error)
-                return Disposables.create()
-            }
+            let observable = Observable<Peripheral>.create { [weak self] observer in
+                guard let strongSelf = self else {
+                    observer.onError(BluetoothError.destroyed)
+                    return Disposables.create()
+                }
+                if let error = BluetoothError(state: strongSelf.centralManager.state) {
+                    observer.onError(error)
+                    return Disposables.create()
+                }
 
-            guard !peripheral.isConnected else {
-                observer.onNext(peripheral)
-                observer.onCompleted()
-                return Disposables.create()
-            }
+                guard !peripheral.isConnected else {
+                    observer.onNext(peripheral)
+                    observer.onCompleted()
+                    return Disposables.create()
+                }
 
-            let disposable = success.amb(error).subscribe(observer)
+                let disposable = success.amb(error).subscribe(observer)
 
-            strongSelf.centralManager.connect(peripheral.peripheral, options: options)
+                strongSelf.centralManager.connect(peripheral.peripheral, options: options)
 
-            return Disposables.create { [weak self] in
-                guard let strongSelf = self else { return }
-                if !peripheral.isConnected {
-                    strongSelf.centralManager.cancelPeripheralConnection(peripheral.peripheral)
-                    disposable.dispose()
+                return Disposables.create { [weak self] in
+                    guard let strongSelf = self else { return }
+                    if !peripheral.isConnected {
+                        strongSelf.centralManager.cancelPeripheralConnection(peripheral.peripheral)
+                        disposable.dispose()
+                    }
                 }
             }
-        }
 
-        return ensure(.poweredOn, observable: observable)
+            return ensure(.poweredOn, observable: observable)
     }
 
     /// Cancels an active or pending local connection to a `Peripheral` after observable subscription. It is not guaranteed
@@ -291,7 +287,7 @@ public class BluetoothManager {
                     return peripheralTable.map {
                         Peripheral(manager: strongSelf, peripheral: $0)
                     }
-                }
+            }
         }
         return ensure(.poweredOn, observable: observable)
     }
@@ -308,7 +304,7 @@ public class BluetoothManager {
                     return peripheralTable.map {
                         Peripheral(manager: strongSelf, peripheral: $0)
                     }
-                }
+            }
         }
         return ensure(.poweredOn, observable: observable)
     }
@@ -339,7 +335,7 @@ public class BluetoothManager {
                 .filter { $0.0 == peripheral.peripheral }
                 .map { (_, error) -> T in
                     throw BluetoothError.peripheralDisconnected(peripheral, error)
-                }
+            }
         }
     }
 
@@ -359,25 +355,25 @@ public class BluetoothManager {
 
     func monitorPeripheral(on peripheralAction: Observable<RxPeripheralType>, peripheral: Peripheral)
         -> Observable<Peripheral> {
-        let observable =
-            peripheralAction
-            .filter { $0 == peripheral.peripheral }
-            .map { _ in peripheral }
-        return ensure(.poweredOn, observable: observable)
+            let observable =
+                peripheralAction
+                    .filter { $0 == peripheral.peripheral }
+                    .map { _ in peripheral }
+            return ensure(.poweredOn, observable: observable)
     }
 
     #if os(iOS)
-        /// Emits `RestoredState` instance, when state of `BluetoothManager` has been restored,
-        /// Should only be called once in the lifetime of the app
-        /// - Returns: Observable which emits next events state has been restored
-        public func listenOnRestoredState() -> Observable<RestoredState> {
-            return centralManager
-                .rx_willRestoreState
-                .take(1)
-                .flatMap { [weak self] dict -> Observable<RestoredState> in
-                    guard let strongSelf = self else { throw BluetoothError.destroyed }
-                    return .just(RestoredState(restoredStateDictionary: dict, bluetoothManager: strongSelf))
-                }
+    /// Emits `RestoredState` instance, when state of `BluetoothManager` has been restored,
+    /// Should only be called once in the lifetime of the app
+    /// - Returns: Observable which emits next events state has been restored
+    public func listenOnRestoredState() -> Observable<RestoredState> {
+        return centralManager
+            .rx_willRestoreState
+            .take(1)
+            .flatMap { [weak self] dict -> Observable<RestoredState> in
+                guard let strongSelf = self else { throw BluetoothError.destroyed }
+                return .just(RestoredState(restoredStateDictionary: dict, bluetoothManager: strongSelf))
         }
+    }
     #endif
 }

--- a/Source/Observable+QueueSubscribeOn.swift
+++ b/Source/Observable+QueueSubscribeOn.swift
@@ -25,6 +25,8 @@ import RxSwift
 
 /// Queue which is used for queueing subscriptions for queueSubscribeOn operator.
 class SerializedSubscriptionQueue {
+    let lock = NSLock()
+
     /// First element on queue is curently subscribed and not completed
     /// observable. All others are queued for subscription when the first
     /// one is finished.
@@ -34,6 +36,7 @@ class SerializedSubscriptionQueue {
     /// into empty queue it's subscribed immediately. Otherwise
     /// it waits for completion from other observables.
     func queueSubscription(observable: DelayedObservableType) {
+        lock.lock(); defer { lock.unlock() }
         let execute = queue.isEmpty
         queue.append(observable)
         if execute {
@@ -43,6 +46,7 @@ class SerializedSubscriptionQueue {
     }
 
     func unsubscribe(observable: DelayedObservableType) {
+        lock.lock(); defer { lock.unlock() }
         // Find index of observable which should be unsubscribed
         // and remove it from queue
         if let index = queue.index(where: { $0 === observable }) {

--- a/Tests/BluetoothManagerSpec+Scanning.swift
+++ b/Tests/BluetoothManagerSpec+Scanning.swift
@@ -42,7 +42,7 @@ class BluetoothManagerScanningSpec: QuickSpec {
             fakePeripheral = FakePeripheral()
             fakeCentralManager = FakeCentralManager()
             testScheduler = TestScheduler(initialClock: 0, resolution: 1.0, simulateProcessingDelay: false)
-            manager = BluetoothManager(centralManager: fakeCentralManager, queueScheduler: testScheduler)
+            manager = BluetoothManager(centralManager: fakeCentralManager)
         }
 
         describe("scanning devices") {

--- a/Tests/ObservableSpec+QueueSubscribeOn.swift
+++ b/Tests/ObservableSpec+QueueSubscribeOn.swift
@@ -51,7 +51,7 @@ class ObservableQueueSubscribeOnSpec: QuickSpec {
             var users: [ScheduledObservable<Int>]!
 
             beforeEach {
-                serializedQueue = SerializedSubscriptionQueue(scheduler: testScheduler)
+                serializedQueue = SerializedSubscriptionQueue()
             }
 
             context("when there are two users registering cold subscriptions on queue") {


### PR DESCRIPTION
Scanning observable is currently able to delay scan subscription when other one is in progress and due to different parameters cannot be shared. Previously subscription queue was subscribing and disposing on specified thread. This caused an issue where next scan subscription could happen before disposal of previous one even when from user perspective order was different.

I decided to remove subscribing on different thread as library is not guaranteed to be thread safe at all. This commit fixes case when start -> stop scan cycle performed quickly causes observable to not emit scan results. 