### PR TITLE
Allow redirecting logs.

### DIFF
--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -218,7 +218,7 @@ extension Reactive where Base == RxBluetoothKitLog {
      * - it delivers events on `MainScheduler.instance`
      * - `share(scope: .whileConnected)` sharing strategy
      */
-    var log: Observable<String> {
+    public var log: Observable<String> {
         return RxBluetoothKitLog.subject.asObserver()
             .observeOn(MainScheduler.instance)
             .catchErrorJustReturn("")


### PR DESCRIPTION
This PR allows catching the logs emitted by `RxBluetoothKitLog` and redirect them to a different place rather then only printing the logs to the standard output. 

The idea addresses a debug use case where the bluetooth hardware team may not be able to debug the application in Xcode itself and requires a different way to view the logs emitted by `RxBluetoothKit` (e.g. through debug UI inside the application itself).

The observable mimics the `RxCocoa` trait `Signal`.

If this PR will be merged, it would be great to see a quick fix or minor release like `4.0.2` or `4.1.0`.