### PR TITLE
Added CB types for mocking

### DIFF
--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -13,8 +13,6 @@
 		0A339D771FA1C10D008385C8 /* CBPeripheralDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2FF3311F9EAD5300A12E10 /* CBPeripheralDelegateWrapper.swift */; };
 		0A7B27D11F9F1710003F950E /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A7B27D01F9F1710003F950E /* RxSwift.framework */; };
 		0A7B27D21F9F176D003F950E /* ScanOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C221CBE3DEE005DEA5B /* ScanOperation.swift */; };
-		0A7B27D31F9F176D003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B27D41F9F176D003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B27D51F9F176D003F950E /* BluetoothManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0E1CBE3DEE005DEA5B /* BluetoothManager.swift */; };
 		0A7B27D61F9F176D003F950E /* AdvertisementData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0C1CBE3DEE005DEA5B /* AdvertisementData.swift */; };
 		0A7B27D71F9F176D003F950E /* BluetoothState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EF38C81D86EE1F00F9F468 /* BluetoothState.swift */; };
@@ -25,40 +23,24 @@
 		0A7B27DC1F9F1771003F950E /* BluetoothError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0D1CBE3DEE005DEA5B /* BluetoothError.swift */; };
 		0A7B27DD1F9F1771003F950E /* UUIDIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */; };
 		0A7B27DE1F9F1771003F950E /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74B16841ED417AA006D5996 /* Logging.swift */; };
-		0A7B27DF1F9F1773003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B27E01F9F1773003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B27E11F9F1773003F950E /* Characteristic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C101CBE3DEE005DEA5B /* Characteristic.swift */; };
-		0A7B27E21F9F1776003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B27E31F9F1776003F950E /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C231CBE3DEE005DEA5B /* Service.swift */; };
-		0A7B27E41F9F1776003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B27E51F9F177A003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B27E61F9F177A003F950E /* ScannedPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C211CBE3DEE005DEA5B /* ScannedPeripheral.swift */; };
 		0A7B27E71F9F177A003F950E /* Peripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C161CBE3DEE005DEA5B /* Peripheral.swift */; };
-		0A7B27E81F9F177A003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B27E91F9F177A003F950E /* DeviceIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26509A761CC1270100EBA319 /* DeviceIdentifiers.swift */; };
 		0A7B27EA1F9F177A003F950E /* Peripheral+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26509A781CC1275E00EBA319 /* Peripheral+Convenience.swift */; };
-		0A7B27EB1F9F177C003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B27EC1F9F177C003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B27ED1F9F177C003F950E /* Descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C121CBE3DEE005DEA5B /* Descriptor.swift */; };
 		0A7B27FC1F9F190F003F950E /* RxBluetoothKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A7B27F31F9F190F003F950E /* RxBluetoothKit.framework */; };
 		0A7B28131F9F1964003F950E /* ObservableSpec+QueueSubscribeOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2666FD0A1CCE431B005E81CE /* ObservableSpec+QueueSubscribeOn.swift */; };
 		0A7B28141F9F1964003F950E /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2666FD0B1CCE431B005E81CE /* Utilities.swift */; };
 		0A7B28151F9F1AE1003F950E /* RxBluetoothKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 2666FCEE1CCE42A5005E81CE /* RxBluetoothKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0A7B28181F9F1B05003F950E /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A7B28171F9F1B05003F950E /* RxSwift.framework */; };
-		0A7B28191F9F1B21003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B281A1F9F1B21003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B281B1F9F1B21003F950E /* Descriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C121CBE3DEE005DEA5B /* Descriptor.swift */; };
-		0A7B281C1F9F1B25003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B281D1F9F1B25003F950E /* ScannedPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C211CBE3DEE005DEA5B /* ScannedPeripheral.swift */; };
 		0A7B281E1F9F1B25003F950E /* Peripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C161CBE3DEE005DEA5B /* Peripheral.swift */; };
-		0A7B281F1F9F1B25003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B28201F9F1B25003F950E /* DeviceIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26509A761CC1270100EBA319 /* DeviceIdentifiers.swift */; };
 		0A7B28211F9F1B25003F950E /* Peripheral+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26509A781CC1275E00EBA319 /* Peripheral+Convenience.swift */; };
-		0A7B28221F9F1B29003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B28231F9F1B29003F950E /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C231CBE3DEE005DEA5B /* Service.swift */; };
-		0A7B28241F9F1B29003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B28251F9F1B2E003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B28261F9F1B2E003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B28271F9F1B2E003F950E /* Characteristic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C101CBE3DEE005DEA5B /* Characteristic.swift */; };
 		0A7B28281F9F1B33003F950E /* Observable+QueueSubscribeOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C151CBE3DEE005DEA5B /* Observable+QueueSubscribeOn.swift */; };
 		0A7B28291F9F1B33003F950E /* Unimplemented.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C241CBE3DEE005DEA5B /* Unimplemented.swift */; };
@@ -68,8 +50,6 @@
 		0A7B282D1F9F1B33003F950E /* UUIDIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */; };
 		0A7B282E1F9F1B33003F950E /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74B16841ED417AA006D5996 /* Logging.swift */; };
 		0A7B282F1F9F1B39003F950E /* ScanOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C221CBE3DEE005DEA5B /* ScanOperation.swift */; };
-		0A7B28301F9F1B39003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B28311F9F1B39003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B28321F9F1B39003F950E /* BluetoothManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0E1CBE3DEE005DEA5B /* BluetoothManager.swift */; };
 		0A7B28331F9F1B39003F950E /* AdvertisementData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1299C0C1CBE3DEE005DEA5B /* AdvertisementData.swift */; };
 		0A7B28341F9F1B39003F950E /* BluetoothState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EF38C81D86EE1F00F9F468 /* BluetoothState.swift */; };
@@ -77,15 +57,10 @@
 		0A7B283B1F9F1C3C003F950E /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A7B28381F9F1C3C003F950E /* Quick.framework */; };
 		0A7B283C1F9F1C3C003F950E /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A7B28391F9F1C3C003F950E /* Nimble.framework */; };
 		0A7B283D1F9F1C71003F950E /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A7B28171F9F1B05003F950E /* RxSwift.framework */; };
-		0A7B283E1F9F1CE8003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B283F1F9F1CE8003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B28401F9F1CE8003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B28411F9F1CE8003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B28421F9F1CE8003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B28441F9F1CEF003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B28451F9F1CEF003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B28461F9F1CEF003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
-		0A7B28471F9F1E27003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
+		1D596B3C1FEABC11002C3F1C /* CBCharacteristicType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D596B3B1FEABC11002C3F1C /* CBCharacteristicType.swift */; };
+		1D596B3D1FEABC11002C3F1C /* CBCharacteristicType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D596B3B1FEABC11002C3F1C /* CBCharacteristicType.swift */; };
+		1D596B3E1FEABC11002C3F1C /* CBCharacteristicType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D596B3B1FEABC11002C3F1C /* CBCharacteristicType.swift */; };
+		1D596B3F1FEABC11002C3F1C /* CBCharacteristicType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D596B3B1FEABC11002C3F1C /* CBCharacteristicType.swift */; };
 		1DC2485C1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC2485B1FEA6AB80071229C /* CBCentralManagerType.swift */; };
 		1DC2485D1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC2485B1FEA6AB80071229C /* CBCentralManagerType.swift */; };
 		1DC2485E1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC2485B1FEA6AB80071229C /* CBCentralManagerType.swift */; };
@@ -134,6 +109,14 @@
 		26752FA61D89C630003D8D38 /* BluetoothState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EF38C81D86EE1F00F9F468 /* BluetoothState.swift */; };
 		26EF38C91D86EE1F00F9F468 /* BluetoothState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EF38C81D86EE1F00F9F468 /* BluetoothState.swift */; };
 		26F3034B1CF0D49D00D74EBF /* RestoredState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F3034A1CF0D49D00D74EBF /* RestoredState.swift */; };
+		37B6438534F7C7B01A19BC1C /* CBDescriptorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B6447B327567A6BECE66BD /* CBDescriptorType.swift */; };
+		37B64486007C21F3B8F592ED /* CBServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B64E4513E347081D5DB15F /* CBServiceType.swift */; };
+		37B644FA9C2F31A421D12CC1 /* CBServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B64E4513E347081D5DB15F /* CBServiceType.swift */; };
+		37B645EB6B93452523AA1DC1 /* CBServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B64E4513E347081D5DB15F /* CBServiceType.swift */; };
+		37B64996C5B51A3BD3224B84 /* CBDescriptorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B6447B327567A6BECE66BD /* CBDescriptorType.swift */; };
+		37B64A9C1E01AB6BDC10162E /* CBServiceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B64E4513E347081D5DB15F /* CBServiceType.swift */; };
+		37B64B7F9D9BC4173DF64073 /* CBDescriptorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B6447B327567A6BECE66BD /* CBDescriptorType.swift */; };
+		37B64F348732405F810EE7D5 /* CBDescriptorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B6447B327567A6BECE66BD /* CBDescriptorType.swift */; };
 		A10F298A1CDCD6E100593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5A1CCE65CD005E81CE /* RxSwift.framework */; };
 		A10F298B1CDCD6E400593284 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FE5E1CCE65EE005E81CE /* RxSwift.framework */; };
 		A10F29A11CDCD74B00593284 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A10F29921CDCD72200593284 /* Nimble.framework */; };
@@ -209,6 +192,7 @@
 		0A7B28371F9F1C3C003F950E /* RxTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTest.framework; path = Carthage/Build/tvOS/RxTest.framework; sourceTree = SOURCE_ROOT; };
 		0A7B28381F9F1C3C003F950E /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = SOURCE_ROOT; };
 		0A7B28391F9F1C3C003F950E /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
+		1D596B3B1FEABC11002C3F1C /* CBCharacteristicType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBCharacteristicType.swift; sourceTree = "<group>"; };
 		1DC2485B1FEA6AB80071229C /* CBCentralManagerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBCentralManagerType.swift; sourceTree = "<group>"; };
 		1DC248601FEA6AE20071229C /* CBPeripheralType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBPeripheralType.swift; sourceTree = "<group>"; };
 		26509A761CC1270100EBA319 /* DeviceIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceIdentifiers.swift; sourceTree = "<group>"; };
@@ -226,6 +210,8 @@
 		2666FE5E1CCE65EE005E81CE /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/Mac/RxSwift.framework; sourceTree = SOURCE_ROOT; };
 		26EF38C81D86EE1F00F9F468 /* BluetoothState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BluetoothState.swift; sourceTree = "<group>"; };
 		26F3034A1CF0D49D00D74EBF /* RestoredState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestoredState.swift; sourceTree = "<group>"; };
+		37B6447B327567A6BECE66BD /* CBDescriptorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CBDescriptorType.swift; sourceTree = "<group>"; };
+		37B64E4513E347081D5DB15F /* CBServiceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CBServiceType.swift; sourceTree = "<group>"; };
 		A10F29911CDCD72200593284 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = SOURCE_ROOT; };
 		A10F29921CDCD72200593284 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		A10F29991CDCD73A00593284 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = SOURCE_ROOT; };
@@ -383,6 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				A1299C101CBE3DEE005DEA5B /* Characteristic.swift */,
+				1D596B3B1FEABC11002C3F1C /* CBCharacteristicType.swift */,
 			);
 			name = Characteristic;
 			sourceTree = "<group>";
@@ -391,6 +378,7 @@
 			isa = PBXGroup;
 			children = (
 				A1299C231CBE3DEE005DEA5B /* Service.swift */,
+				37B64E4513E347081D5DB15F /* CBServiceType.swift */,
 			);
 			name = Service;
 			sourceTree = "<group>";
@@ -412,6 +400,7 @@
 			isa = PBXGroup;
 			children = (
 				A1299C121CBE3DEE005DEA5B /* Descriptor.swift */,
+				37B6447B327567A6BECE66BD /* CBDescriptorType.swift */,
 			);
 			name = Descriptor;
 			sourceTree = "<group>";
@@ -859,38 +848,31 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0A7B27D41F9F176D003F950E /* (null) in Sources */,
-				0A7B27E81F9F177A003F950E /* (null) in Sources */,
 				0A7B27E71F9F177A003F950E /* Peripheral.swift in Sources */,
-				0A7B27E21F9F1776003F950E /* (null) in Sources */,
 				1DC248631FEA6AE20071229C /* CBPeripheralType.swift in Sources */,
 				0A7B27DE1F9F1771003F950E /* Logging.swift in Sources */,
 				0A7B27DB1F9F1771003F950E /* Boxes.swift in Sources */,
-				0A7B27EB1F9F177C003F950E /* (null) in Sources */,
 				0A7B27D21F9F176D003F950E /* ScanOperation.swift in Sources */,
 				0A7B27E31F9F1776003F950E /* Service.swift in Sources */,
 				0A7B27DA1F9F1771003F950E /* Observable+Absorb.swift in Sources */,
 				0A339D761FA1C10B008385C8 /* CBCentralManagerDelegateWrapper.swift in Sources */,
 				0A339D771FA1C10D008385C8 /* CBPeripheralDelegateWrapper.swift in Sources */,
 				0A7B27D81F9F1771003F950E /* Observable+QueueSubscribeOn.swift in Sources */,
-				0A7B27EC1F9F177C003F950E /* (null) in Sources */,
 				1DC2485E1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */,
 				0A7B27D51F9F176D003F950E /* BluetoothManager.swift in Sources */,
-				0A7B27E51F9F177A003F950E /* (null) in Sources */,
 				0A7B27E61F9F177A003F950E /* ScannedPeripheral.swift in Sources */,
 				0A7B27DC1F9F1771003F950E /* BluetoothError.swift in Sources */,
 				0A7B27E11F9F1773003F950E /* Characteristic.swift in Sources */,
-				0A7B27E41F9F1776003F950E /* (null) in Sources */,
 				0A7B27E91F9F177A003F950E /* DeviceIdentifiers.swift in Sources */,
-				0A7B27DF1F9F1773003F950E /* (null) in Sources */,
 				0A7B27D61F9F176D003F950E /* AdvertisementData.swift in Sources */,
 				0A7B27DD1F9F1771003F950E /* UUIDIdentifiable.swift in Sources */,
 				0A7B27ED1F9F177C003F950E /* Descriptor.swift in Sources */,
 				0A7B27D91F9F1771003F950E /* Unimplemented.swift in Sources */,
 				0A7B27D71F9F176D003F950E /* BluetoothState.swift in Sources */,
-				0A7B27E01F9F1773003F950E /* (null) in Sources */,
-				0A7B27D31F9F176D003F950E /* (null) in Sources */,
 				0A7B27EA1F9F177A003F950E /* Peripheral+Convenience.swift in Sources */,
+				1D596B3E1FEABC11002C3F1C /* CBCharacteristicType.swift in Sources */,
+				37B64B7F9D9BC4173DF64073 /* CBDescriptorType.swift in Sources */,
+				37B645EB6B93452523AA1DC1 /* CBServiceType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -903,33 +885,26 @@
 				0A7B28321F9F1B39003F950E /* BluetoothManager.swift in Sources */,
 				0A339D741FA1C0ED008385C8 /* CBPeripheralDelegateWrapper.swift in Sources */,
 				1DC248641FEA6AE20071229C /* CBPeripheralType.swift in Sources */,
-				0A7B28241F9F1B29003F950E /* (null) in Sources */,
 				0A7B282E1F9F1B33003F950E /* Logging.swift in Sources */,
 				0A7B28201F9F1B25003F950E /* DeviceIdentifiers.swift in Sources */,
 				0A339D751FA1C10A008385C8 /* CBCentralManagerDelegateWrapper.swift in Sources */,
-				0A7B28301F9F1B39003F950E /* (null) in Sources */,
-				0A7B28191F9F1B21003F950E /* (null) in Sources */,
 				0A7B282F1F9F1B39003F950E /* ScanOperation.swift in Sources */,
-				0A7B28261F9F1B2E003F950E /* (null) in Sources */,
-				0A7B28251F9F1B2E003F950E /* (null) in Sources */,
 				0A7B282C1F9F1B33003F950E /* BluetoothError.swift in Sources */,
 				1DC2485F1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */,
 				0A7B281E1F9F1B25003F950E /* Peripheral.swift in Sources */,
-				0A7B281C1F9F1B25003F950E /* (null) in Sources */,
-				0A7B281A1F9F1B21003F950E /* (null) in Sources */,
-				0A7B281F1F9F1B25003F950E /* (null) in Sources */,
 				0A7B282A1F9F1B33003F950E /* Observable+Absorb.swift in Sources */,
 				0A7B28211F9F1B25003F950E /* Peripheral+Convenience.swift in Sources */,
 				0A7B28341F9F1B39003F950E /* BluetoothState.swift in Sources */,
-				0A7B28221F9F1B29003F950E /* (null) in Sources */,
 				0A7B28231F9F1B29003F950E /* Service.swift in Sources */,
 				0A7B28271F9F1B2E003F950E /* Characteristic.swift in Sources */,
 				0A7B281B1F9F1B21003F950E /* Descriptor.swift in Sources */,
-				0A7B28311F9F1B39003F950E /* (null) in Sources */,
 				0A7B282B1F9F1B33003F950E /* Boxes.swift in Sources */,
 				0A7B28331F9F1B39003F950E /* AdvertisementData.swift in Sources */,
 				0A7B281D1F9F1B25003F950E /* ScannedPeripheral.swift in Sources */,
 				0A7B282D1F9F1B33003F950E /* UUIDIdentifiable.swift in Sources */,
+				1D596B3F1FEABC11002C3F1C /* CBCharacteristicType.swift in Sources */,
+				37B64996C5B51A3BD3224B84 /* CBDescriptorType.swift in Sources */,
+				37B644FA9C2F31A421D12CC1 /* CBServiceType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -938,16 +913,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0A7B28131F9F1964003F950E /* ObservableSpec+QueueSubscribeOn.swift in Sources */,
-				0A7B28441F9F1CEF003F950E /* (null) in Sources */,
 				0A7B28141F9F1964003F950E /* Utilities.swift in Sources */,
-				0A7B283F1F9F1CE8003F950E /* (null) in Sources */,
-				0A7B28451F9F1CEF003F950E /* (null) in Sources */,
-				0A7B28421F9F1CE8003F950E /* (null) in Sources */,
-				0A7B28411F9F1CE8003F950E /* (null) in Sources */,
-				0A7B28461F9F1CEF003F950E /* (null) in Sources */,
-				0A7B28471F9F1E27003F950E /* (null) in Sources */,
-				0A7B28401F9F1CE8003F950E /* (null) in Sources */,
-				0A7B283E1F9F1CE8003F950E /* (null) in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -976,8 +942,11 @@
 				2666FE321CCE4732005E81CE /* Descriptor.swift in Sources */,
 				2666FE4A1CCE4732005E81CE /* AdvertisementData.swift in Sources */,
 				2666FE421CCE4732005E81CE /* Observable+Absorb.swift in Sources */,
+				1D596B3C1FEABC11002C3F1C /* CBCharacteristicType.swift in Sources */,
 				2666FE341CCE4732005E81CE /* ScannedPeripheral.swift in Sources */,
 				26F3034B1CF0D49D00D74EBF /* RestoredState.swift in Sources */,
+				37B6438534F7C7B01A19BC1C /* CBDescriptorType.swift in Sources */,
+				37B64A9C1E01AB6BDC10162E /* CBServiceType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1016,6 +985,9 @@
 				2666FE2F1CCE4731005E81CE /* AdvertisementData.swift in Sources */,
 				2666FE271CCE4731005E81CE /* Observable+Absorb.swift in Sources */,
 				2666FE191CCE4731005E81CE /* ScannedPeripheral.swift in Sources */,
+				1D596B3D1FEABC11002C3F1C /* CBCharacteristicType.swift in Sources */,
+				37B64F348732405F810EE7D5 /* CBDescriptorType.swift in Sources */,
+				37B64486007C21F3B8F592ED /* CBServiceType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -86,6 +86,14 @@
 		0A7B28451F9F1CEF003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B28461F9F1CEF003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
 		0A7B28471F9F1E27003F950E /* (null) in Sources */ = {isa = PBXBuildFile; };
+		1DC2485C1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC2485B1FEA6AB80071229C /* CBCentralManagerType.swift */; };
+		1DC2485D1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC2485B1FEA6AB80071229C /* CBCentralManagerType.swift */; };
+		1DC2485E1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC2485B1FEA6AB80071229C /* CBCentralManagerType.swift */; };
+		1DC2485F1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC2485B1FEA6AB80071229C /* CBCentralManagerType.swift */; };
+		1DC248611FEA6AE20071229C /* CBPeripheralType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC248601FEA6AE20071229C /* CBPeripheralType.swift */; };
+		1DC248621FEA6AE20071229C /* CBPeripheralType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC248601FEA6AE20071229C /* CBPeripheralType.swift */; };
+		1DC248631FEA6AE20071229C /* CBPeripheralType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC248601FEA6AE20071229C /* CBPeripheralType.swift */; };
+		1DC248641FEA6AE20071229C /* CBPeripheralType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC248601FEA6AE20071229C /* CBPeripheralType.swift */; };
 		2666FD8E1CCE457C005E81CE /* RxBluetoothKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FD841CCE457C005E81CE /* RxBluetoothKit.framework */; };
 		2666FD9D1CCE45E3005E81CE /* RxBluetoothKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 2666FCEE1CCE42A5005E81CE /* RxBluetoothKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2666FDAD1CCE4626005E81CE /* RxBluetoothKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FDA31CCE4626005E81CE /* RxBluetoothKit.framework */; };
@@ -201,6 +209,8 @@
 		0A7B28371F9F1C3C003F950E /* RxTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTest.framework; path = Carthage/Build/tvOS/RxTest.framework; sourceTree = SOURCE_ROOT; };
 		0A7B28381F9F1C3C003F950E /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = SOURCE_ROOT; };
 		0A7B28391F9F1C3C003F950E /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
+		1DC2485B1FEA6AB80071229C /* CBCentralManagerType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBCentralManagerType.swift; sourceTree = "<group>"; };
+		1DC248601FEA6AE20071229C /* CBPeripheralType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBPeripheralType.swift; sourceTree = "<group>"; };
 		26509A761CC1270100EBA319 /* DeviceIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceIdentifiers.swift; sourceTree = "<group>"; };
 		26509A781CC1275E00EBA319 /* Peripheral+Convenience.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Peripheral+Convenience.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		2666FCED1CCE42A5005E81CE /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Source/Info.plist; sourceTree = "<group>"; };
@@ -334,6 +344,14 @@
 			name = tvOS;
 			sourceTree = "<group>";
 		};
+		1DC2485A1FEA6A9B0071229C /* CentralManager */ = {
+			isa = PBXGroup;
+			children = (
+				1DC2485B1FEA6AB80071229C /* CBCentralManagerType.swift */,
+			);
+			name = CentralManager;
+			sourceTree = "<group>";
+		};
 		265CD5F91CBED2E4007120AB /* BluetoothManager */ = {
 			isa = PBXGroup;
 			children = (
@@ -385,6 +403,7 @@
 				26509A761CC1270100EBA319 /* DeviceIdentifiers.swift */,
 				26509A781CC1275E00EBA319 /* Peripheral+Convenience.swift */,
 				BB2FF3311F9EAD5300A12E10 /* CBPeripheralDelegateWrapper.swift */,
+				1DC248601FEA6AE20071229C /* CBPeripheralType.swift */,
 			);
 			name = Peripheral;
 			sourceTree = "<group>";
@@ -507,6 +526,7 @@
 		A1299BD71CBE3D61005DEA5B /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				1DC2485A1FEA6A9B0071229C /* CentralManager */,
 				265CD5FE1CBED348007120AB /* Descriptor */,
 				265CD5FD1CBED33D007120AB /* Peripheral */,
 				265CD5FC1CBED339007120AB /* Service */,
@@ -843,6 +863,7 @@
 				0A7B27E81F9F177A003F950E /* (null) in Sources */,
 				0A7B27E71F9F177A003F950E /* Peripheral.swift in Sources */,
 				0A7B27E21F9F1776003F950E /* (null) in Sources */,
+				1DC248631FEA6AE20071229C /* CBPeripheralType.swift in Sources */,
 				0A7B27DE1F9F1771003F950E /* Logging.swift in Sources */,
 				0A7B27DB1F9F1771003F950E /* Boxes.swift in Sources */,
 				0A7B27EB1F9F177C003F950E /* (null) in Sources */,
@@ -853,6 +874,7 @@
 				0A339D771FA1C10D008385C8 /* CBPeripheralDelegateWrapper.swift in Sources */,
 				0A7B27D81F9F1771003F950E /* Observable+QueueSubscribeOn.swift in Sources */,
 				0A7B27EC1F9F177C003F950E /* (null) in Sources */,
+				1DC2485E1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */,
 				0A7B27D51F9F176D003F950E /* BluetoothManager.swift in Sources */,
 				0A7B27E51F9F177A003F950E /* (null) in Sources */,
 				0A7B27E61F9F177A003F950E /* ScannedPeripheral.swift in Sources */,
@@ -880,6 +902,7 @@
 				0A7B28291F9F1B33003F950E /* Unimplemented.swift in Sources */,
 				0A7B28321F9F1B39003F950E /* BluetoothManager.swift in Sources */,
 				0A339D741FA1C0ED008385C8 /* CBPeripheralDelegateWrapper.swift in Sources */,
+				1DC248641FEA6AE20071229C /* CBPeripheralType.swift in Sources */,
 				0A7B28241F9F1B29003F950E /* (null) in Sources */,
 				0A7B282E1F9F1B33003F950E /* Logging.swift in Sources */,
 				0A7B28201F9F1B25003F950E /* DeviceIdentifiers.swift in Sources */,
@@ -890,6 +913,7 @@
 				0A7B28261F9F1B2E003F950E /* (null) in Sources */,
 				0A7B28251F9F1B2E003F950E /* (null) in Sources */,
 				0A7B282C1F9F1B33003F950E /* BluetoothError.swift in Sources */,
+				1DC2485F1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */,
 				0A7B281E1F9F1B25003F950E /* Peripheral.swift in Sources */,
 				0A7B281C1F9F1B25003F950E /* (null) in Sources */,
 				0A7B281A1F9F1B21003F950E /* (null) in Sources */,
@@ -939,6 +963,7 @@
 				2666FE461CCE4732005E81CE /* ScanOperation.swift in Sources */,
 				BB2FF3351F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift in Sources */,
 				2666FE351CCE4732005E81CE /* Peripheral.swift in Sources */,
+				1DC2485C1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */,
 				D74B16851ED417AA006D5996 /* Logging.swift in Sources */,
 				2666FE441CCE4732005E81CE /* Boxes.swift in Sources */,
 				BB2FF3321F9EAD5300A12E10 /* CBPeripheralDelegateWrapper.swift in Sources */,
@@ -947,6 +972,7 @@
 				2666FE451CCE4732005E81CE /* BluetoothError.swift in Sources */,
 				FA947A3B1EB1C41C000ED0B1 /* UUIDIdentifiable.swift in Sources */,
 				2666FE3E1CCE4732005E81CE /* Characteristic.swift in Sources */,
+				1DC248611FEA6AE20071229C /* CBPeripheralType.swift in Sources */,
 				2666FE321CCE4732005E81CE /* Descriptor.swift in Sources */,
 				2666FE4A1CCE4732005E81CE /* AdvertisementData.swift in Sources */,
 				2666FE421CCE4732005E81CE /* Observable+Absorb.swift in Sources */,
@@ -975,10 +1001,12 @@
 				2666FE1C1CCE4731005E81CE /* DeviceIdentifiers.swift in Sources */,
 				2666FE2B1CCE4731005E81CE /* ScanOperation.swift in Sources */,
 				FA947A3C1EB1C42F000ED0B1 /* UUIDIdentifiable.swift in Sources */,
+				1DC2485D1FEA6AB80071229C /* CBCentralManagerType.swift in Sources */,
 				2666FE1A1CCE4731005E81CE /* Peripheral.swift in Sources */,
 				BB2FF3361F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift in Sources */,
 				2666FE291CCE4731005E81CE /* Boxes.swift in Sources */,
 				2666FE1D1CCE4731005E81CE /* Peripheral+Convenience.swift in Sources */,
+				1DC248621FEA6AE20071229C /* CBPeripheralType.swift in Sources */,
 				BB2FF3331F9EAF1600A12E10 /* CBPeripheralDelegateWrapper.swift in Sources */,
 				26752FA61D89C630003D8D38 /* BluetoothState.swift in Sources */,
 				2666FE1F1CCE4731005E81CE /* Service.swift in Sources */,

--- a/Source/CBCentralManagerType.swift
+++ b/Source/CBCentralManagerType.swift
@@ -1,0 +1,65 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import CoreBluetooth
+
+/// CBCentralManagerType is protocol that has exact same methods and variables as CBCentralManager
+/// and CBCentralManager implements that protocol.
+/// The only difference here is bluetoothState - it is because in iOS 10 there was type change of
+/// state property and we can not create 2 variables with different type and same name.
+/// It is needed for creating mocks of CBCentralManager in tests.
+
+protocol CBCentralManagerType: class {
+    var delegate: CBCentralManagerDelegate? { get set }
+    var bluetoothState: BluetoothState { get }
+    func connect(_ peripheral: CBPeripheralType, options: [String: Any]?)
+    func scanForPeripherals(withServices serviceUUIDs: [CBUUID]?, options: [String: Any]?)
+    func stopScan()
+    func cancelPeripheralConnection(_ peripheral: CBPeripheralType)
+    func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBUUID]) -> [CBPeripheralType]
+    func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> [CBPeripheralType]
+}
+
+extension CBCentralManager: CBCentralManagerType {
+    var bluetoothState: BluetoothState {
+        return BluetoothState(rawValue: state.rawValue) ?? .unknown
+    }
+    func connect(_ peripheral: CBPeripheralType, options: [String: Any]?) {
+        if let realPeripheral = peripheral as? CBPeripheral {
+            connect(realPeripheral, options: options)
+        }
+    }
+    func cancelPeripheralConnection(_ peripheral: CBPeripheralType) {
+        if let realPeripheral = peripheral as? CBPeripheral {
+            cancelPeripheralConnection(realPeripheral)
+        }
+    }
+    func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBUUID]) -> [CBPeripheralType] {
+        let peripherals: [CBPeripheral] = retrieveConnectedPeripherals(withServices: serviceUUIDs)
+        return peripherals as [CBPeripheralType]
+    }
+    func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> [CBPeripheralType] {
+        let peripherals: [CBPeripheral] = retrievePeripherals(withIdentifiers: identifiers)
+        return peripherals as [CBPeripheralType]
+    }
+}

--- a/Source/CBCharacteristicType.swift
+++ b/Source/CBCharacteristicType.swift
@@ -1,0 +1,42 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import CoreBluetooth
+
+/// CBCharacteristicType is protocol that has almost same methods and variables as CBCharacteristic
+/// and CBCharacteristic implements that protocol.
+/// It is needed for creating mocks of CBCharacteristic in tests.
+
+protocol CBCharacteristicType: class {
+    var value: Data? { get }
+    var uuid: CBUUID { get }
+    var isNotifying: Bool { get }
+    var properties: CBCharacteristicProperties { get }
+    var descriptorTypes: [CBDescriptorType]? { get }
+}
+
+extension CBCharacteristic: CBCharacteristicType {
+    var descriptorTypes: [CBDescriptorType]? {
+        return descriptors
+    }
+}

--- a/Source/CBDescriptorType.swift
+++ b/Source/CBDescriptorType.swift
@@ -1,0 +1,37 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import CoreBluetooth
+
+/// CBDescriptorType is protocol that has exact same methods and variables as CBDescriptor
+/// and CBDescriptor implements that protocol.
+/// It is needed for creating mocks of CBDescriptor in tests.
+
+protocol CBDescriptorType: class {
+    var value: Any? { get }
+    var uuid: CBUUID { get }
+}
+
+extension CBDescriptor: CBDescriptorType {
+
+}

--- a/Source/CBPeripheralType.swift
+++ b/Source/CBPeripheralType.swift
@@ -30,20 +30,20 @@ protocol CBPeripheralType: class {
     var delegate: CBPeripheralDelegate? { get set }
     var state: CBPeripheralState { get }
     var name: String? { get }
-    var services: [CBService]? { get }
+    var serviceTypes: [CBServiceType]? { get }
     var identifier: UUID { get }
     var canSendWriteWithoutResponse: Bool { get }
     func discoverServices(_ serviceUUIDs: [CBUUID]?)
-    func discoverIncludedServices(_ includedServiceUUIDs: [CBUUID]?, for service: CBService)
-    func discoverCharacteristics(_ characteristicUUIDs: [CBUUID]?, for service: CBService)
-    func readValue(for characteristic: CBCharacteristic)
-    func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType)
-    func readValue(for descriptor: CBDescriptor)
-    func writeValue(_ data: Data, for descriptor: CBDescriptor)
+    func discoverIncludedServices(_ includedServiceUUIDs: [CBUUID]?, for service: CBServiceType)
+    func discoverCharacteristics(_ characteristicUUIDs: [CBUUID]?, for service: CBServiceType)
+    func readValue(for characteristic: CBCharacteristicType)
+    func writeValue(_ data: Data, for characteristic: CBCharacteristicType, type: CBCharacteristicWriteType)
+    func readValue(for descriptor: CBDescriptorType)
+    func writeValue(_ data: Data, for descriptor: CBDescriptorType)
     @available(iOS 9.0, OSX 10.12, *)
     func maximumWriteValueLength(for type: CBCharacteristicWriteType) -> Int
-    func setNotifyValue(_ enabled: Bool, for characteristic: CBCharacteristic)
-    func discoverDescriptors(for characteristic: CBCharacteristic)
+    func setNotifyValue(_ enabled: Bool, for characteristic: CBCharacteristicType)
+    func discoverDescriptors(for characteristic: CBCharacteristicType)
     func readRSSI()
     #if os(iOS) || os(tvOS) || os(watchOS)
     @available(iOS 11, tvOS 11, watchOS 4, *)
@@ -55,5 +55,56 @@ extension CBPeripheral: CBPeripheralType {
     // there is no CBPeripheral.identifier property on macOS
     open override var identifier: UUID {
         return value(forKey: "identifier") as! NSUUID as UUID
+    }
+
+    var serviceTypes: [CBServiceType]? {
+        return services
+    }
+
+    func discoverIncludedServices(_ includedServiceUUIDs: [CBUUID]?, for service: CBServiceType) {
+        if let realService = service as? CBService {
+            discoverIncludedServices(includedServiceUUIDs, for: realService)
+        }
+    }
+
+    func discoverCharacteristics(_ characteristicUUIDs: [CBUUID]?, for service: CBServiceType) {
+        if let realService = service as? CBService {
+            discoverCharacteristics(characteristicUUIDs, for: realService)
+        }
+    }
+
+    func readValue(for characteristic: CBCharacteristicType) {
+        if let realCharacteristic = characteristic as? CBCharacteristic {
+            readValue(for: realCharacteristic)
+        }
+    }
+
+    func writeValue(_ data: Data, for characteristic: CBCharacteristicType, type: CBCharacteristicWriteType) {
+        if let realCharacteristic = characteristic as? CBCharacteristic {
+            writeValue(data, for: realCharacteristic, type: type)
+        }
+    }
+
+    func readValue(for descriptor: CBDescriptorType) {
+        if let realDescriptor = descriptor as? CBDescriptor {
+            readValue(for: realDescriptor)
+        }
+    }
+
+    func writeValue(_ data: Data, for descriptor: CBDescriptorType) {
+        if let realDescriptor = descriptor as? CBDescriptor {
+            writeValue(data, for: realDescriptor)
+        }
+    }
+
+    func setNotifyValue(_ enabled: Bool, for characteristic: CBCharacteristicType) {
+        if let realCharacteristic = characteristic as? CBCharacteristic {
+            setNotifyValue(enabled, for: realCharacteristic)
+        }
+    }
+    func discoverDescriptors(for characteristic: CBCharacteristicType) {
+        if let realCharacteristic = characteristic as? CBCharacteristic {
+            discoverDescriptors(for: realCharacteristic)
+        }
     }
 }

--- a/Source/CBPeripheralType.swift
+++ b/Source/CBPeripheralType.swift
@@ -40,7 +40,7 @@ protocol CBPeripheralType: class {
     func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType)
     func readValue(for descriptor: CBDescriptor)
     func writeValue(_ data: Data, for descriptor: CBDescriptor)
-    @available(iOS 9.0, *)
+    @available(iOS 9.0, OSX 10.12, *)
     func maximumWriteValueLength(for type: CBCharacteristicWriteType) -> Int
     func setNotifyValue(_ enabled: Bool, for characteristic: CBCharacteristic)
     func discoverDescriptors(for characteristic: CBCharacteristic)
@@ -52,4 +52,8 @@ protocol CBPeripheralType: class {
 }
 
 extension CBPeripheral: CBPeripheralType {
+    // there is no CBPeripheral.identifier property on macOS
+    open override var identifier: UUID {
+        return value(forKey: "identifier") as! NSUUID as UUID
+    }
 }

--- a/Source/CBPeripheralType.swift
+++ b/Source/CBPeripheralType.swift
@@ -1,0 +1,55 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import CoreBluetooth
+
+/// CBPeripheralType is protocol that has exact same methods and variables as CBPeripheral
+/// and CBPeripheral implements that protocol.
+/// It is needed for creating mocks of CBPeripheral in tests.
+
+protocol CBPeripheralType: class {
+    var delegate: CBPeripheralDelegate? { get set }
+    var state: CBPeripheralState { get }
+    var name: String? { get }
+    var services: [CBService]? { get }
+    var identifier: UUID { get }
+    var canSendWriteWithoutResponse: Bool { get }
+    func discoverServices(_ serviceUUIDs: [CBUUID]?)
+    func discoverIncludedServices(_ includedServiceUUIDs: [CBUUID]?, for service: CBService)
+    func discoverCharacteristics(_ characteristicUUIDs: [CBUUID]?, for service: CBService)
+    func readValue(for characteristic: CBCharacteristic)
+    func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType)
+    func readValue(for descriptor: CBDescriptor)
+    func writeValue(_ data: Data, for descriptor: CBDescriptor)
+    @available(iOS 9.0, *)
+    func maximumWriteValueLength(for type: CBCharacteristicWriteType) -> Int
+    func setNotifyValue(_ enabled: Bool, for characteristic: CBCharacteristic)
+    func discoverDescriptors(for characteristic: CBCharacteristic)
+    func readRSSI()
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    @available(iOS 11, tvOS 11, watchOS 4, *)
+    func openL2CAPChannel(_ PSM: CBL2CAPPSM)
+    #endif
+}
+
+extension CBPeripheral: CBPeripheralType {
+}

--- a/Source/CBServiceType.swift
+++ b/Source/CBServiceType.swift
@@ -1,0 +1,45 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import CoreBluetooth
+
+/// CBServiceType is protocol that has exact same methods and variables as CBService
+/// and CBService implements that protocol.
+/// It is needed for creating mocks of CBService in tests.
+
+protocol CBServiceType: class {
+    var isPrimary: Bool { get }
+    var uuid: CBUUID { get }
+    var includedServiceTypes: [CBServiceType]? { get }
+    var characteristicTypes: [CBCharacteristicType]? { get }
+}
+
+extension CBService: CBServiceType {
+    var includedServiceTypes: [CBServiceType]? {
+        return includedServices
+    }
+
+    var characteristicTypes: [CBCharacteristicType]? {
+        return characteristics
+    }
+}

--- a/Source/Characteristic.swift
+++ b/Source/Characteristic.swift
@@ -28,9 +28,10 @@ import CoreBluetooth
 
 /// Characteristic is a class implementing ReactiveX which wraps CoreBluetooth functions related to interaction with [CBCharacteristic](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCharacteristic_Class/)
 public class Characteristic {
-    public let characteristic: CBCharacteristic
     /// Service which contains this characteristic
     public let service: Service
+
+    private let characteristic: CBCharacteristicType
 
     /// Current value of characteristic. If value is not present - it's `nil`.
     public var value: Data? {
@@ -54,12 +55,16 @@ public class Characteristic {
 
     /// Value of this property is an array of `Descriptor` objects. They provide more detailed information about characteristics value.
     public var descriptors: [Descriptor]? {
-        return characteristic.descriptors?.map { Descriptor(descriptor: $0, characteristic: self) }
+        return characteristic.descriptorTypes?.map { Descriptor(descriptor: $0, characteristic: self) }
     }
 
-    init(characteristic: CBCharacteristic, service: Service) {
+    init(characteristic: CBCharacteristicType, service: Service) {
         self.characteristic = characteristic
         self.service = service
+    }
+
+    public func getCharacteristic() -> CBCharacteristic {
+        return characteristic as! CBCharacteristic
     }
 
     /// Function that triggers descriptors discovery for characteristic.
@@ -132,5 +137,5 @@ extension Characteristic: Equatable {}
 /// - parameter rhs: Second characteristic to compare
 /// - returns: True if both characteristics are the same.
 public func == (lhs: Characteristic, rhs: Characteristic) -> Bool {
-    return lhs.characteristic == rhs.characteristic
+    return lhs.getCharacteristic() == rhs.getCharacteristic()
 }

--- a/Source/Descriptor.swift
+++ b/Source/Descriptor.swift
@@ -29,10 +29,10 @@ import RxSwift
 /// Descriptors provide more information about a characteristic’s value.
 public class Descriptor {
 
-    public let descriptor: CBDescriptor
-
     /// Characteristic to which this descriptor belongs.
     public let characteristic: Characteristic
+
+    private let descriptor: CBDescriptorType
 
     /// The Bluetooth UUID of the `Descriptor` instance.
     public var uuid: CBUUID {
@@ -44,9 +44,13 @@ public class Descriptor {
         return descriptor.value
     }
 
-    init(descriptor: CBDescriptor, characteristic: Characteristic) {
+    init(descriptor: CBDescriptorType, characteristic: Characteristic) {
         self.descriptor = descriptor
         self.characteristic = characteristic
+    }
+
+    public func getDescriptor() -> CBDescriptor {
+        return descriptor as! CBDescriptor
     }
 
     /// Function that allow to monitor writes that happened for descriptor.
@@ -86,5 +90,5 @@ extension Descriptor: Equatable {}
 /// - parameter rhs: Second descriptor to compare
 /// - returns: True if both descriptor are the same.
 public func == (lhs: Descriptor, rhs: Descriptor) -> Bool {
-    return lhs.descriptor == rhs.descriptor
+    return lhs.getDescriptor() == rhs.getDescriptor()
 }

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -30,12 +30,14 @@ import CoreBluetooth
 /// allowing to talk to peripheral like discovering characteristics, services and all of the read/write calls.
 public class Peripheral {
     public let manager: BluetoothManager
+    private let peripheral: CBPeripheralType
+    private let delegateWrapper: CBPeripheralDelegateWrapper
 
     /// Creates new `Peripheral`
     /// - parameter manager: Central instance which is used to perform all of the necessary operations.
     /// - parameter peripheral: Instance representing specific peripheral allowing to perform operations on it.
     /// - parameter delegateWrapper: Wrapper on CoreBluetooth's peripheral callbacks.
-    init(manager: BluetoothManager, peripheral: CBPeripheral, delegateWrapper: CBPeripheralDelegateWrapper) {
+    init(manager: BluetoothManager, peripheral: CBPeripheralType, delegateWrapper: CBPeripheralDelegateWrapper) {
       self.manager = manager
       self.peripheral = peripheral
       self.delegateWrapper = delegateWrapper
@@ -45,13 +47,9 @@ public class Peripheral {
     /// Creates new `Peripheral`
     /// - parameter manager: Central instance which is used to perform all of the necessary operations.
     /// - parameter peripheral: Instance representing specific peripheral allowing to perform operations on it.
-    convenience init(manager: BluetoothManager, peripheral: CBPeripheral) {
+    convenience init(manager: BluetoothManager, peripheral: CBPeripheralType) {
       self.init(manager: manager, peripheral: peripheral, delegateWrapper: CBPeripheralDelegateWrapper())
     }
-
-    /// Implementation of peripheral
-    public let peripheral: CBPeripheral
-    private let delegateWrapper: CBPeripheralDelegateWrapper
 
     ///  Continuous value indicating if peripheral is in connected state. This is continuous value, which first emits `.Next` with current state, and later whenever state change occurs
     public var rx_isConnected: Observable<Bool> {
@@ -80,7 +78,7 @@ public class Peripheral {
 
     /// Unique identifier of `Peripheral` instance. Assigned once peripheral is discovered by the system.
     public var identifier: UUID {
-        return peripheral.value(forKey: "identifier") as! NSUUID as UUID
+        return peripheral.identifier
     }
 
     /// A list of services that have been discovered. Analogous to   [services](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBPeripheral_Class/#//apple_ref/occ/instp/CBPeripheral/services) of `CBPeripheral`.
@@ -95,6 +93,11 @@ public class Peripheral {
     /// `peripheralIsReadyToSendWriteWithoutResponse:` will be called.
     public var canSendWriteWithoutResponse: Bool {
         return peripheral.canSendWriteWithoutResponse
+    }
+
+    /// Returns wrapped CBPeripheral instance
+    public func getPeripheral() -> CBPeripheral {
+        return peripheral as! CBPeripheral
     }
 
     /// Establishes local connection to the peripheral.
@@ -587,5 +590,5 @@ extension Peripheral: Equatable {}
  - returns: True if both peripherals are the same
  */
 public func == (lhs: Peripheral, rhs: Peripheral) -> Bool {
-    return lhs.peripheral == rhs.peripheral
+    return lhs.getPeripheral() == rhs.getPeripheral()
 }

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -83,7 +83,7 @@ public class Peripheral {
 
     /// A list of services that have been discovered. Analogous to   [services](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBPeripheral_Class/#//apple_ref/occ/instp/CBPeripheral/services) of `CBPeripheral`.
     public var services: [Service]? {
-        return peripheral.services?.map {
+        return peripheral.serviceTypes?.map {
             Service(peripheral: self, service: $0)
         }
     }
@@ -168,7 +168,7 @@ public class Peripheral {
         }
         let observable = delegateWrapper
             .peripheralDidDiscoverIncludedServicesForService
-            .filter { $0.0 == service.service }
+            .filter { $0.0 == service.getService() }
             .flatMap { [weak self] (service, error) -> Observable<[Service]> in
                 guard let strongSelf = self else { throw BluetoothError.destroyed }
                 guard let includedRxServices = service.includedServices, error == nil else {
@@ -185,7 +185,7 @@ public class Peripheral {
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in
-                self?.peripheral.discoverIncludedServices(includedServiceUUIDs, for: service.service)
+                self?.peripheral.discoverIncludedServices(includedServiceUUIDs, for: service.getService())
             }
         )
         .asSingle()
@@ -210,7 +210,7 @@ public class Peripheral {
         }
         let observable = delegateWrapper
             .peripheralDidDiscoverCharacteristicsForService
-            .filter { $0.0 == service.service }
+            .filter { $0.0 == service.getService() }
             .flatMap { (cbService, error) -> Observable<[Characteristic]> in
                 guard let cbCharacteristics = cbService.characteristics, error == nil else {
                     throw BluetoothError.characteristicsDiscoveryFailed(service, error)
@@ -226,7 +226,7 @@ public class Peripheral {
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in
-                self?.peripheral.discoverCharacteristics(characteristicUUIDs, for: service.service)
+                self?.peripheral.discoverCharacteristics(characteristicUUIDs, for: service.getService())
             }
         ).asSingle()
     }
@@ -238,7 +238,7 @@ public class Peripheral {
     public func monitorWrite(for characteristic: Characteristic) -> Observable<Characteristic> {
         let observable = delegateWrapper
             .peripheralDidWriteValueForCharacteristic
-            .filter { return $0.0 == characteristic.characteristic }
+            .filter { return $0.0 == characteristic.getCharacteristic() }
             .map { (_, error) -> Characteristic in
                 if let error = error {
                     throw BluetoothError.characteristicWriteFailed(characteristic, error)
@@ -278,7 +278,7 @@ public class Peripheral {
             return strongSelf.ensureValidPeripheralStateAndCallIfSucceeded(
                 for: observable,
                 postSubscriptionCall: { [weak self] in
-                    self?.peripheral.writeValue(data, for: characteristic.characteristic, type: type)
+                    self?.peripheral.writeValue(data, for: characteristic.getCharacteristic(), type: type)
                 }
             )
         }
@@ -308,7 +308,7 @@ public class Peripheral {
     public func monitorValueUpdate(for characteristic: Characteristic) -> Observable<Characteristic> {
         let observable = delegateWrapper
             .peripheralDidUpdateValueForCharacteristic
-            .filter { $0.0 == characteristic.characteristic }
+            .filter { $0.0 == characteristic.getCharacteristic() }
             .map { (_, error) -> Characteristic in
                 if let error = error {
                     throw BluetoothError.characteristicReadFailed(characteristic, error)
@@ -327,7 +327,7 @@ public class Peripheral {
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in
-                self?.peripheral.readValue(for: characteristic.characteristic)
+                self?.peripheral.readValue(for: characteristic.getCharacteristic())
             }
         ).asSingle()
     }
@@ -343,7 +343,7 @@ public class Peripheral {
                                for characteristic: Characteristic) -> Single<Characteristic> {
         let observable = delegateWrapper
             .peripheralDidUpdateNotificationStateForCharacteristic
-            .filter { $0.0 == characteristic.characteristic }
+            .filter { $0.0 == characteristic.getCharacteristic() }
             .take(1)
             .map { (_, error) -> Characteristic in
                 if let error = error {
@@ -354,7 +354,7 @@ public class Peripheral {
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in
-                self?.peripheral.setNotifyValue(enabled, for: characteristic.characteristic)
+                self?.peripheral.setNotifyValue(enabled, for: characteristic.getCharacteristic())
             }
         ).asSingle()
     }
@@ -386,12 +386,12 @@ public class Peripheral {
     /// - Returns: `Single` that emits `Next` with array of `Descriptor` instances, once they're discovered.
     public func discoverDescriptors(for characteristic: Characteristic) -> Single<[Descriptor]> {
         if let descriptors = characteristic.descriptors {
-            let resultDescriptors = descriptors.map { Descriptor(descriptor: $0.descriptor, characteristic: characteristic) }
+            let resultDescriptors = descriptors.map { Descriptor(descriptor: $0.getDescriptor(), characteristic: characteristic) }
             return ensureValidPeripheralState(for: .just(resultDescriptors)).asSingle()
         }
         let observable = delegateWrapper
             .peripheralDidDiscoverDescriptorsForCharacteristic
-            .filter { $0.0 == characteristic.characteristic }
+            .filter { $0.0 == characteristic.getCharacteristic() }
             .take(1)
             .map { (cbCharacteristic, error) -> [Descriptor] in
                 if let descriptors = cbCharacteristic.descriptors, error == nil {
@@ -404,7 +404,7 @@ public class Peripheral {
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in
-                self?.peripheral.discoverDescriptors(for: characteristic.characteristic)
+                self?.peripheral.discoverDescriptors(for: characteristic.getCharacteristic())
             }
         ).asSingle()
     }
@@ -416,7 +416,7 @@ public class Peripheral {
     public func monitorWrite(for descriptor: Descriptor) -> Observable<Descriptor> {
         let observable = delegateWrapper
             .peripheralDidWriteValueForDescriptor
-            .filter { $0.0 == descriptor.descriptor }
+            .filter { $0.0 == descriptor.getDescriptor() }
             .map { (_, error) -> Descriptor in
                 if let error = error {
                     throw BluetoothError.descriptorWriteFailed(descriptor, error)
@@ -433,7 +433,7 @@ public class Peripheral {
     public func monitorValueUpdate(for descriptor: Descriptor) -> Observable<Descriptor> {
         let observable = delegateWrapper
             .peripheralDidUpdateValueForDescriptor
-            .filter { $0.0 == descriptor.descriptor }
+            .filter { $0.0 == descriptor.getDescriptor() }
             .map { (_, error) -> Descriptor in
                 if let error = error {
                     throw BluetoothError.descriptorReadFailed(descriptor, error)
@@ -452,7 +452,7 @@ public class Peripheral {
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in
-                self?.peripheral.readValue(for: descriptor.descriptor) }
+                self?.peripheral.readValue(for: descriptor.getDescriptor()) }
         )
         .asSingle()
     }
@@ -466,7 +466,7 @@ public class Peripheral {
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: monitorWrite,
             postSubscriptionCall: { [weak self] in
-                self?.peripheral.writeValue(data, for: descriptor.descriptor) }
+                self?.peripheral.writeValue(data, for: descriptor.getDescriptor()) }
         )
         .asSingle()
     }

--- a/Source/Service.swift
+++ b/Source/Service.swift
@@ -27,10 +27,10 @@ import RxSwift
 // swiftlint:disable line_length
 /// Service is a class implementing ReactiveX which wraps CoreBluetooth functions related to interaction with [CBService](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBService_Class/)
 public class Service {
-    public let service: CBService
-
     /// Peripheral to which this service belongs
     public let peripheral: Peripheral
+
+    private let service: CBServiceType
 
     /// True if service is primary service
     public var isPrimary: Bool {
@@ -44,21 +44,25 @@ public class Service {
 
     /// Service's included services
     public var includedServices: [Service]? {
-        return service.includedServices?.map {
+        return service.includedServiceTypes?.map {
             Service(peripheral: peripheral, service: $0)
         }
     }
 
     /// Service's characteristics
     public var characteristics: [Characteristic]? {
-        return service.characteristics?.map {
+        return service.characteristicTypes?.map {
             Characteristic(characteristic: $0, service: self)
         }
     }
 
-    init(peripheral: Peripheral, service: CBService) {
+    init(peripheral: Peripheral, service: CBServiceType) {
         self.service = service
         self.peripheral = peripheral
+    }
+
+    public func getService() -> CBService {
+        return service as! CBService
     }
 
     /// Function that triggers characteristics discovery for specified Services and identifiers. Discovery is called after
@@ -87,5 +91,5 @@ extension Service: Equatable {}
 /// - parameter rhs: Second service
 /// - returns: True if services are the same.
 public func == (lhs: Service, rhs: Service) -> Bool {
-    return lhs.service == rhs.service
+    return lhs.getService() == rhs.getService()
 }


### PR DESCRIPTION
This PR is a proposal to how we want handle testing in library #168. For couple days I've been investigating how to make best approach which will allow make as less problems as possible in future development.

From my perspective best approach would be to:
- create new protocol types which are conformed by `CoreBluetooth` types (made in this PR)
- make use of that protocol types in `BluetoothManager`, `Peripheral`, `Service`, `Characteristic` classes (made in this PR)
- manually create mocks of that types in tests
- write tests with injecting those mocks to `BluetoothManager` and `Peripheral` instances

Some details from my research:
- I've been investigation option with not creating those protocols and doing automated generation of new  `BluetoothManager` test class that will have different entry parameter (I think that it was @Kacper20 and @Cierpliwy approach) but doing this with [Sourcery](https://github.com/krzysztofzablocki/Sourcery) library would be very hard, complicated and could lead to many issues related to that code generation. 
- I've been testing automated generation of mocks using [Sourcery](https://github.com/krzysztofzablocki/Sourcery). There is example template on [sourcery github](https://github.com/krzysztofzablocki/Sourcery/blob/master/Templates/Templates/AutoMockable.stencil), but it need a lot of changes to make work with our types (e.g. it doesn't handle methods with same names, which is possible in swift). It is possible to create template that works with our types but it will need to be very complicated and will be hard to maintain it in future. 
- I've also found library [SwiftyMocky](https://github.com/MakeAWishFoundation/SwiftyMocky) which is using Sourcery for creating their own implementation of mock. It looks like it is working. Problem here is that this library is too much for our needs. It has it's own api wrapper for stubbing, veryfing of mock which may works for some simple cases but may also cause problems in more complicated code. I think that depending so much on that library could cause problems in future development
- We have only 2 types (`CBCentralManager` and `CBPeripheral`)  so I think adding here additional libraries for mock generation would be too much for our needs. That's why my proposal is to add those mocks manually.

I know that you had something different approach in mind, so if you have any doubts or question just write it here ;)

BREAKING CHANGE: I've made change to public wrapped CB type properties, e.g. before if user wanted to get `CBService` he called `Service.service`, now he will need change this to `Service.getService()`. 