### PR TITLE
Emergency fix to allow `RxSwift` to update `4.1.0`

### DIFF
--- a/RxBluetoothKit.podspec
+++ b/RxBluetoothKit.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Source/*.swift'
   s.frameworks   = 'CoreBluetooth'
-  s.dependency 'RxSwift', '~> 4.0.0'
+  s.dependency 'RxSwift', '~> 4.0'
 end


### PR DESCRIPTION
This is an emergency fix to allow projects that depend on `RxBluetoothKit` to update `RxSwift` to `4.1.0` and newer.

@Cierpliwy please merge, add a tag `4.0.2` and run `pod trunk push RxBluetoothKit.podspec`
