### PR TITLE
Simpler scanning and improved monitorDisconnection

### DIFF
--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -58,6 +58,12 @@
 		1D1BC8982004ABB4004C5F36 /* BluetoothManagerTest+RetrievePeripherals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1BC8972004ABB4004C5F36 /* BluetoothManagerTest+RetrievePeripherals.swift */; };
 		1D1BC8992004ABB4004C5F36 /* BluetoothManagerTest+RetrievePeripherals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1BC8972004ABB4004C5F36 /* BluetoothManagerTest+RetrievePeripherals.swift */; };
 		1D1BC89A2004ABB4004C5F36 /* BluetoothManagerTest+RetrievePeripherals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1BC8972004ABB4004C5F36 /* BluetoothManagerTest+RetrievePeripherals.swift */; };
+		1D417F88200F436900354750 /* BluetoothManagerTest+ScanForPeripherals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D417F87200F436900354750 /* BluetoothManagerTest+ScanForPeripherals.swift */; };
+		1D417F89200F436900354750 /* BluetoothManagerTest+ScanForPeripherals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D417F87200F436900354750 /* BluetoothManagerTest+ScanForPeripherals.swift */; };
+		1D417F8A200F436900354750 /* BluetoothManagerTest+ScanForPeripherals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D417F87200F436900354750 /* BluetoothManagerTest+ScanForPeripherals.swift */; };
+		1D417F8C200F877100354750 /* BaseBluetoothManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D417F8B200F877100354750 /* BaseBluetoothManagerTest.swift */; };
+		1D417F8D200F877100354750 /* BaseBluetoothManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D417F8B200F877100354750 /* BaseBluetoothManagerTest.swift */; };
+		1D417F8E200F877100354750 /* BaseBluetoothManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D417F8B200F877100354750 /* BaseBluetoothManagerTest.swift */; };
 		1D490B531FFF8E1000D3F871 /* _BluetoothError.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D490B451FFF8E0B00D3F871 /* _BluetoothError.generated.swift */; };
 		1D490B541FFF8E1000D3F871 /* _BluetoothManager.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D490B4A1FFF8E0B00D3F871 /* _BluetoothManager.generated.swift */; };
 		1D490B571FFF8E1000D3F871 /* _Characteristic.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D490B481FFF8E0B00D3F871 /* _Characteristic.generated.swift */; };
@@ -217,6 +223,8 @@
 		0A7B28381F9F1C3C003F950E /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = SOURCE_ROOT; };
 		0A7B28391F9F1C3C003F950E /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		1D1BC8972004ABB4004C5F36 /* BluetoothManagerTest+RetrievePeripherals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BluetoothManagerTest+RetrievePeripherals.swift"; sourceTree = "<group>"; };
+		1D417F87200F436900354750 /* BluetoothManagerTest+ScanForPeripherals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BluetoothManagerTest+ScanForPeripherals.swift"; sourceTree = "<group>"; };
+		1D417F8B200F877100354750 /* BaseBluetoothManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBluetoothManagerTest.swift; sourceTree = "<group>"; };
 		1D490B431FFF8E0A00D3F871 /* _Descriptor.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _Descriptor.generated.swift; sourceTree = "<group>"; };
 		1D490B451FFF8E0B00D3F871 /* _BluetoothError.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _BluetoothError.generated.swift; sourceTree = "<group>"; };
 		1D490B471FFF8E0B00D3F871 /* _Peripheral.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _Peripheral.generated.swift; sourceTree = "<group>"; };
@@ -364,6 +372,8 @@
 			children = (
 				1D1BC8972004ABB4004C5F36 /* BluetoothManagerTest+RetrievePeripherals.swift */,
 				1DC4234D200CEDFE009994B1 /* BluetoothManagerTest+MonitorDisconnection.swift */,
+				1D417F87200F436900354750 /* BluetoothManagerTest+ScanForPeripherals.swift */,
+				1D417F8B200F877100354750 /* BaseBluetoothManagerTest.swift */,
 			);
 			name = BluetoothManager;
 			sourceTree = "<group>";
@@ -1025,10 +1035,12 @@
 			files = (
 				0A7B28131F9F1964003F950E /* ObservableTest+QueueSubscribeOn.swift in Sources */,
 				1D490B681FFF8E1200D3F871 /* _Descriptor.generated.swift in Sources */,
+				1D417F8A200F436900354750 /* BluetoothManagerTest+ScanForPeripherals.swift in Sources */,
 				1D490B641FFF8E1200D3F871 /* _BluetoothManager.generated.swift in Sources */,
 				1D490B691FFF8E1200D3F871 /* _Peripheral.generated.swift in Sources */,
 				1D490B701FFF8EBE00D3F871 /* _ScannedPeripheral.generated.swift in Sources */,
 				0A7B28141F9F1964003F950E /* Utilities.swift in Sources */,
+				1D417F8E200F877100354750 /* BaseBluetoothManagerTest.swift in Sources */,
 				1DC423472008F0EF009994B1 /* PeripheralDelegateWrapperProviderTest.swift in Sources */,
 				1D1BC89A2004ABB4004C5F36 /* BluetoothManagerTest+RetrievePeripherals.swift in Sources */,
 				1D490B631FFF8E1200D3F871 /* _BluetoothError.generated.swift in Sources */,
@@ -1078,10 +1090,12 @@
 			files = (
 				1D8116C81FFE0F1700147BF5 /* Mock.generated.swift in Sources */,
 				1D490B581FFF8E1000D3F871 /* _Descriptor.generated.swift in Sources */,
+				1D417F88200F436900354750 /* BluetoothManagerTest+ScanForPeripherals.swift in Sources */,
 				1D490B541FFF8E1000D3F871 /* _BluetoothManager.generated.swift in Sources */,
 				1D490B591FFF8E1000D3F871 /* _Peripheral.generated.swift in Sources */,
 				1D490B6E1FFF8EBD00D3F871 /* _ScannedPeripheral.generated.swift in Sources */,
 				2666FDDE1CCE46E2005E81CE /* Utilities.swift in Sources */,
+				1D417F8C200F877100354750 /* BaseBluetoothManagerTest.swift in Sources */,
 				1DC423452008F0EF009994B1 /* PeripheralDelegateWrapperProviderTest.swift in Sources */,
 				1D1BC8982004ABB4004C5F36 /* BluetoothManagerTest+RetrievePeripherals.swift in Sources */,
 				1D490B531FFF8E1000D3F871 /* _BluetoothError.generated.swift in Sources */,
@@ -1130,10 +1144,12 @@
 			files = (
 				1D8116C91FFE0F1700147BF5 /* Mock.generated.swift in Sources */,
 				1D490B601FFF8E1100D3F871 /* _Descriptor.generated.swift in Sources */,
+				1D417F89200F436900354750 /* BluetoothManagerTest+ScanForPeripherals.swift in Sources */,
 				1D490B5C1FFF8E1100D3F871 /* _BluetoothManager.generated.swift in Sources */,
 				1D490B611FFF8E1100D3F871 /* _Peripheral.generated.swift in Sources */,
 				1D490B6F1FFF8EBE00D3F871 /* _ScannedPeripheral.generated.swift in Sources */,
 				2666FDD81CCE46E1005E81CE /* Utilities.swift in Sources */,
+				1D417F8D200F877100354750 /* BaseBluetoothManagerTest.swift in Sources */,
 				1DC423462008F0EF009994B1 /* PeripheralDelegateWrapperProviderTest.swift in Sources */,
 				1D1BC8992004ABB4004C5F36 /* BluetoothManagerTest+RetrievePeripherals.swift in Sources */,
 				1D490B5B1FFF8E1100D3F871 /* _BluetoothError.generated.swift in Sources */,

--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -99,6 +99,9 @@
 		1DC4234A2008F1FF009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC423482008F1DB009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift */; };
 		1DC4234B2008F200009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC423482008F1DB009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift */; };
 		1DC4234C2008F201009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC423482008F1DB009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift */; };
+		1DC4234E200CEDFE009994B1 /* BluetoothManagerTest+MonitorDisconnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC4234D200CEDFE009994B1 /* BluetoothManagerTest+MonitorDisconnection.swift */; };
+		1DC4234F200CEDFE009994B1 /* BluetoothManagerTest+MonitorDisconnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC4234D200CEDFE009994B1 /* BluetoothManagerTest+MonitorDisconnection.swift */; };
+		1DC42350200CEDFE009994B1 /* BluetoothManagerTest+MonitorDisconnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC4234D200CEDFE009994B1 /* BluetoothManagerTest+MonitorDisconnection.swift */; };
 		2666FD8E1CCE457C005E81CE /* RxBluetoothKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FD841CCE457C005E81CE /* RxBluetoothKit.framework */; };
 		2666FD9D1CCE45E3005E81CE /* RxBluetoothKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 2666FCEE1CCE42A5005E81CE /* RxBluetoothKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2666FDAD1CCE4626005E81CE /* RxBluetoothKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2666FDA31CCE4626005E81CE /* RxBluetoothKit.framework */; };
@@ -227,6 +230,7 @@
 		1DC4233E20078315009994B1 /* CBPeripheral+Uuid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CBPeripheral+Uuid.swift"; sourceTree = "<group>"; };
 		1DC423442008F0EF009994B1 /* PeripheralDelegateWrapperProviderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeripheralDelegateWrapperProviderTest.swift; sourceTree = "<group>"; };
 		1DC423482008F1DB009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _PeripheralDelegateWrapperProvider.generated.swift; sourceTree = "<group>"; };
+		1DC4234D200CEDFE009994B1 /* BluetoothManagerTest+MonitorDisconnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BluetoothManagerTest+MonitorDisconnection.swift"; sourceTree = "<group>"; };
 		26509A761CC1270100EBA319 /* DeviceIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceIdentifiers.swift; sourceTree = "<group>"; };
 		26509A781CC1275E00EBA319 /* Peripheral+Convenience.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Peripheral+Convenience.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		2666FCED1CCE42A5005E81CE /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Source/Info.plist; sourceTree = "<group>"; };
@@ -359,6 +363,7 @@
 			isa = PBXGroup;
 			children = (
 				1D1BC8972004ABB4004C5F36 /* BluetoothManagerTest+RetrievePeripherals.swift */,
+				1DC4234D200CEDFE009994B1 /* BluetoothManagerTest+MonitorDisconnection.swift */,
 			);
 			name = BluetoothManager;
 			sourceTree = "<group>";
@@ -1032,6 +1037,7 @@
 				1D490B6A1FFF8E1200D3F871 /* _Service.generated.swift in Sources */,
 				1DC4234C2008F201009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift in Sources */,
 				1D490B671FFF8E1200D3F871 /* _Characteristic.generated.swift in Sources */,
+				1DC42350200CEDFE009994B1 /* BluetoothManagerTest+MonitorDisconnection.swift in Sources */,
 				1D490B741FFF8F1D00D3F871 /* _ScanOperation.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1084,6 +1090,7 @@
 				1D490B5A1FFF8E1000D3F871 /* _Service.generated.swift in Sources */,
 				1DC4234A2008F1FF009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift in Sources */,
 				1D490B571FFF8E1000D3F871 /* _Characteristic.generated.swift in Sources */,
+				1DC4234E200CEDFE009994B1 /* BluetoothManagerTest+MonitorDisconnection.swift in Sources */,
 				1D490B721FFF8F1D00D3F871 /* _ScanOperation.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1135,6 +1142,7 @@
 				1D490B621FFF8E1100D3F871 /* _Service.generated.swift in Sources */,
 				1DC4234B2008F200009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift in Sources */,
 				1D490B5F1FFF8E1100D3F871 /* _Characteristic.generated.swift in Sources */,
+				1DC4234F200CEDFE009994B1 /* BluetoothManagerTest+MonitorDisconnection.swift in Sources */,
 				1D490B731FFF8F1D00D3F871 /* _ScanOperation.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/BluetoothError.swift
+++ b/Source/BluetoothError.swift
@@ -29,6 +29,8 @@ public enum BluetoothError: Error {
     /// To mitigate it dispose all of your subscriptions before deinitializing
     /// object that created Observables that subscriptions are made to.
     case destroyed
+    // Emitted when `BluetoothManager.scanForPeripherals` called and there is already ongoing scan
+    case scanInProgress
     // States
     case bluetoothUnsupported
     case bluetoothUnauthorized
@@ -64,6 +66,11 @@ extension BluetoothError: CustomStringConvertible {
             return """
             The object that is the source of this Observable was destroyed.
             It's programmer's error, please check documentation of error for more details
+            """
+        case .scanInProgress:
+            return """
+            Tried to scan for peripheral when there is already ongoing scan.
+            You can have only 1 ongoing scanning, please check documentation of BluetoothManager for more details
             """
         case .bluetoothUnsupported:
             return "Bluetooth is unsupported"
@@ -134,6 +141,8 @@ extension BluetoothError: Equatable {}
 
 public func == (lhs: BluetoothError, rhs: BluetoothError) -> Bool {
     switch (lhs, rhs) {
+    case (.scanInProgress, .scanInProgress): return true
+    // States
     case (.bluetoothUnsupported, .bluetoothUnsupported): return true
     case (.bluetoothUnauthorized, .bluetoothUnauthorized): return true
     case (.bluetoothPoweredOff, .bluetoothPoweredOff): return true

--- a/Templates/Mock.swifttemplate
+++ b/Templates/Mock.swifttemplate
@@ -113,17 +113,19 @@ class <%= typeToMock.name %>Mock: NSObject {
             let formattedName = methodVariableNames[method.name]!.formattedName
             let methodParamsName = "\(formattedName)Params"
             let methodReturnsName = "\(formattedName)Returns"
+            let methodReturnName = "\(formattedName)Return"
             let isReturningType = !method.returnTypeName.isVoid 
             let methodReturnDeclaration = isReturningType ? " -> \(Utils.changeTypeNameToMock(method.returnTypeName.name))" : "" -%>
     var <%= methodParamsName %>: [(<%= Utils.printMethodParamTypes(method) %>)] = []
 <%      if isReturningType { -%>
     var <%= methodReturnsName %>: [<%= Utils.changeTypeNameToMock(method.returnTypeName.name) %>] = []
+    var <%= methodReturnName %>: <%= Utils.changeTypeNameToMock(method.returnTypeName.name) %>?
 <%      } -%>
     func <%= Utils.printMethodName(method) %><%= methodReturnDeclaration %> {
         <%= methodParamsName %>.append((<%= method.parameters.reduce("", { "\($0)\($1.name), " }).dropLast(2) %>))
 <%          if isReturningType { -%>
         if <%= methodReturnsName %>.isEmpty {
-            fatalError("No return value")
+            return <%= methodReturnName %>!
         } else {
             return <%= methodReturnsName %>.removeFirst()
         }

--- a/Tests/Autogenerated/Mock.generated.swift
+++ b/Tests/Autogenerated/Mock.generated.swift
@@ -21,10 +21,11 @@ class CBCentralManagerMock: NSObject {
 
     var retrievePeripheralsParams: [([UUID])] = []
     var retrievePeripheralsReturns: [[CBPeripheralMock]] = []
+    var retrievePeripheralsReturn: [CBPeripheralMock]?
     func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> [CBPeripheralMock] {
         retrievePeripheralsParams.append((identifiers))
         if retrievePeripheralsReturns.isEmpty {
-            fatalError("No return value")
+            return retrievePeripheralsReturn!
         } else {
             return retrievePeripheralsReturns.removeFirst()
         }
@@ -32,10 +33,11 @@ class CBCentralManagerMock: NSObject {
 
     var retrieveConnectedPeripheralsParams: [([CBUUID])] = []
     var retrieveConnectedPeripheralsReturns: [[CBPeripheralMock]] = []
+    var retrieveConnectedPeripheralsReturn: [CBPeripheralMock]?
     func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBUUID]) -> [CBPeripheralMock] {
         retrieveConnectedPeripheralsParams.append((serviceUUIDs))
         if retrieveConnectedPeripheralsReturns.isEmpty {
-            fatalError("No return value")
+            return retrieveConnectedPeripheralsReturn!
         } else {
             return retrieveConnectedPeripheralsReturns.removeFirst()
         }
@@ -103,10 +105,11 @@ class CBPeripheralMock: NSObject {
 
     var maximumWriteValueLengthParams: [(CBCharacteristicWriteType)] = []
     var maximumWriteValueLengthReturns: [Int] = []
+    var maximumWriteValueLengthReturn: Int?
     func maximumWriteValueLength(for type: CBCharacteristicWriteType) -> Int {
         maximumWriteValueLengthParams.append((type))
         if maximumWriteValueLengthReturns.isEmpty {
-            fatalError("No return value")
+            return maximumWriteValueLengthReturn!
         } else {
             return maximumWriteValueLengthReturns.removeFirst()
         }
@@ -205,10 +208,11 @@ class PeripheralDelegateWrapperProviderMock: NSObject {
 
     var provideParams: [(CBPeripheralMock)] = []
     var provideReturns: [CBPeripheralDelegateWrapperMock] = []
+    var provideReturn: CBPeripheralDelegateWrapperMock?
     func provide(for peripheral: CBPeripheralMock) -> CBPeripheralDelegateWrapperMock {
         provideParams.append((peripheral))
         if provideReturns.isEmpty {
-            fatalError("No return value")
+            return provideReturn!
         } else {
             return provideReturns.removeFirst()
         }

--- a/Tests/Autogenerated/_BluetoothError.generated.swift
+++ b/Tests/Autogenerated/_BluetoothError.generated.swift
@@ -30,6 +30,8 @@ enum _BluetoothError: Error {
     /// To mitigate it dispose all of your subscriptions before deinitializing
     /// object that created Observables that subscriptions are made to.
     case destroyed
+    // Emitted when `_BluetoothManager.scanForPeripherals` called and there is already ongoing scan
+    case scanInProgress
     // States
     case bluetoothUnsupported
     case bluetoothUnauthorized
@@ -65,6 +67,11 @@ extension _BluetoothError: CustomStringConvertible {
             return """
             The object that is the source of this Observable was destroyed.
             It's programmer's error, please check documentation of error for more details
+            """
+        case .scanInProgress:
+            return """
+            Tried to scan for peripheral when there is already ongoing scan.
+            You can have only 1 ongoing scanning, please check documentation of _BluetoothManager for more details
             """
         case .bluetoothUnsupported:
             return "Bluetooth is unsupported"
@@ -135,6 +142,8 @@ extension _BluetoothError: Equatable {}
 
 func == (lhs: _BluetoothError, rhs: _BluetoothError) -> Bool {
     switch (lhs, rhs) {
+    case (.scanInProgress, .scanInProgress): return true
+    // States
     case (.bluetoothUnsupported, .bluetoothUnsupported): return true
     case (.bluetoothUnauthorized, .bluetoothUnauthorized): return true
     case (.bluetoothPoweredOff, .bluetoothPoweredOff): return true

--- a/Tests/Autogenerated/_BluetoothManager.generated.swift
+++ b/Tests/Autogenerated/_BluetoothManager.generated.swift
@@ -50,32 +50,26 @@ class _BluetoothManager {
 
     private let delegateWrapper: CBCentralManagerDelegateWrapperMock
 
-    /// Queue on which all observables are serialised if needed
-    private let subscriptionQueue: SerializedSubscriptionQueue
-
     /// Lock which should be used before accessing any internal structures
     private let lock = NSLock()
 
-    /// Queue of scan operations which are waiting for an execution
-    private var scanQueue: [_ScanOperation] = []
+    /// Ongoing scan disposable
+    private var scanDisposable: Disposable?
 
     // MARK: Initialization
 
     /// Creates new `_BluetoothManager`
     /// - parameter centralManager: Central instance which is used to perform all of the necessary operations
-    /// - parameter queueScheduler: Scheduler on which all serialised operations are executed (such as scans). By default main thread is used.
     /// - parameter delegateWrapper: Wrapper on CoreBluetooth's central manager callbacks.
     /// - parameter peripheralDelegateProvider: Provider for peripheral delegate wrapper.
     init(
       centralManager: CBCentralManagerMock,
-      queueScheduler: SchedulerType = ConcurrentMainScheduler.instance,
       delegateWrapper: CBCentralManagerDelegateWrapperMock,
       peripheralDelegateProvider: PeripheralDelegateWrapperProviderMock
     ) {
         self.centralManager = centralManager
         self.delegateWrapper = delegateWrapper
         self.peripheralDelegateProvider = peripheralDelegateProvider
-        subscriptionQueue = SerializedSubscriptionQueue(scheduler: queueScheduler)
         centralManager.delegate = delegateWrapper
     }
 
@@ -89,7 +83,6 @@ class _BluetoothManager {
         let delegateWrapper = CBCentralManagerDelegateWrapperMock()
         self.init(
             centralManager: CBCentralManagerMock(delegate: delegateWrapper, queue: queue, options: options),
-            queueScheduler: ConcurrentDispatchQueueScheduler(queue: queue),
             delegateWrapper: delegateWrapper,
             peripheralDelegateProvider: PeripheralDelegateWrapperProviderMock()
         )
@@ -117,9 +110,8 @@ class _BluetoothManager {
     ///     .take(2)
     /// ```
     ///
-    /// If different scan is currently in progress and peripherals needed by a user can be discovered by it, new scan is
-    /// shared. Otherwise scan is queued on thread specified in `init(centralManager:queueScheduler:)` and will be executed
-    /// when other scans finished with complete/error event or were unsubscribed.
+    /// There can be only one ongoing scanning. It will return `_BluetoothError.scanInProgress` error if
+    /// this method will be called when there is already ongoing scan.
     /// As a result you will receive `_ScannedPeripheral` which contains `_Peripheral` object, `AdvertisementData` and
     /// peripheral's RSSI registered during discovery. You can then `connectToPeripheral(_:options:)` and do other
     /// operations.
@@ -129,70 +121,44 @@ class _BluetoothManager {
     /// - parameter options: Optional scanning options.
     /// - returns: Infinite stream of scanned peripherals.
     func scanForPeripherals(withServices serviceUUIDs: [CBUUID]?, options: [String: Any]? = nil)
-        -> Observable<_ScannedPeripheral> {
+                    -> Observable<_ScannedPeripheral> {
         return .deferred { [weak self] in
             guard let strongSelf = self else { throw _BluetoothError.destroyed }
-            let observable: Observable<_ScannedPeripheral> = { [weak self] () -> Observable<_ScannedPeripheral> in
-                guard let strongSelf = self else { return .error(_BluetoothError.destroyed) }
-                // If it's possible use existing scan - take if from the queue
-                strongSelf.lock.lock(); defer { strongSelf.lock.unlock() }
-                if let elem = strongSelf.scanQueue.first(where: { $0.shouldAccept(serviceUUIDs) }) {
-                    guard let serviceUUIDs = serviceUUIDs else {
-                        return elem.observable
-                    }
-
-                    // When binding to existing scan we need to make sure that services are
-                    // filtered properly
-                    return elem.observable.filter { scannedPeripheral in
-                        if let services = scannedPeripheral.advertisementData.serviceUUIDs {
-                            return Set(services).isSuperset(of: Set(serviceUUIDs))
-                        }
-                        return false
-                    }
+            let observable: Observable<_ScannedPeripheral> = Observable.create { [weak self] observer in
+                guard let strongSelf = self else {
+                    observer.onError(_BluetoothError.destroyed)
+                    return Disposables.create()
                 }
-
-                let scanOperationBox = WeakBox<_ScanOperation>()
-
-                // Create new scan which will be processed in a queue
-                let operation = Observable.create { [weak self] (element: AnyObserver<_ScannedPeripheral>) -> Disposable in
-                    guard let strongSelf = self else { return Disposables.create() }
-                    // Observable which will emit next element, when peripheral is discovered.
-                    let disposable = strongSelf.delegateWrapper.didDiscoverPeripheral
+                strongSelf.lock.lock(); defer { strongSelf.lock.unlock() }
+                if strongSelf.scanDisposable != nil {
+                    observer.onError(_BluetoothError.scanInProgress)
+                    return Disposables.create()
+                }
+                strongSelf.scanDisposable = strongSelf.delegateWrapper.didDiscoverPeripheral
                         .flatMap { [weak self] (cbPeripheral, advertisment, rssi) -> Observable<_ScannedPeripheral> in
-                            guard let strongSelf = self else { throw _BluetoothError.destroyed }
+                            guard let strongSelf = self else {
+                                throw _BluetoothError.destroyed
+                            }
                             let peripheral = _Peripheral(manager: strongSelf, peripheral: cbPeripheral)
                             let advertismentData = AdvertisementData(advertisementData: advertisment)
                             return .just(_ScannedPeripheral(peripheral: peripheral,
-                                                           advertisementData: advertismentData, rssi: rssi))
+                                    advertisementData: advertismentData, rssi: rssi))
                         }
-                        .subscribe(element)
+                        .subscribe(observer)
 
-                    // Start scanning for devices
-                    strongSelf.centralManager.scanForPeripherals(withServices: serviceUUIDs, options: options)
+                strongSelf.centralManager.scanForPeripherals(withServices: serviceUUIDs, options: options)
 
-                    return Disposables.create { [weak self] in
-                        guard let strongSelf = self else { return }
-                        // When disposed, stop all scans, and remove scanning operation from queue
-                        strongSelf.centralManager.stopScan()
-                        disposable.dispose()
-                        do { strongSelf.lock.lock(); defer { strongSelf.lock.unlock() }
-                            if let index = strongSelf.scanQueue.index(where: { $0 == scanOperationBox.value! }) {
-                                strongSelf.scanQueue.remove(at: index)
-                            }
-                        }
+                return Disposables.create {
+                    guard let strongSelf = self else { return }
+                    // When disposed, stop scan and dispose scanning
+                    strongSelf.centralManager.stopScan()
+                    do { strongSelf.lock.lock(); defer { strongSelf.lock.unlock() }
+                        strongSelf.scanDisposable?.dispose()
+                        strongSelf.scanDisposable = nil
                     }
                 }
-                .queueSubscribe(on: strongSelf.subscriptionQueue)
-                .publish()
-                .refCount()
+            }
 
-                let scanOperation = _ScanOperation(uuids: serviceUUIDs, observable: operation)
-                strongSelf.scanQueue.append(scanOperation)
-
-                scanOperationBox.value = scanOperation
-                return operation
-            }()
-            // Allow scanning as long as bluetooth is powered on
             return strongSelf.ensure(.poweredOn, observable: observable)
         }
     }

--- a/Tests/BaseBluetoothManagerTest.swift
+++ b/Tests/BaseBluetoothManagerTest.swift
@@ -1,0 +1,39 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import XCTest
+
+class BaseBluetoothManagerTest: XCTestCase {
+    var manager: _BluetoothManager!
+    
+    var centralManagerMock: CBCentralManagerMock!
+    var wrapperMock: CBCentralManagerDelegateWrapperMock!
+    var wrapperProviderMock: PeripheralDelegateWrapperProviderMock!
+    
+    func setUpProperties() {
+        centralManagerMock = CBCentralManagerMock()
+        wrapperMock = CBCentralManagerDelegateWrapperMock()
+        wrapperProviderMock = PeripheralDelegateWrapperProviderMock()
+        manager = _BluetoothManager(centralManager: centralManagerMock, delegateWrapper: wrapperMock, peripheralDelegateProvider: wrapperProviderMock)
+    }
+}

--- a/Tests/BluetoothManagerTest+MonitorDisconnection.swift
+++ b/Tests/BluetoothManagerTest+MonitorDisconnection.swift
@@ -1,0 +1,162 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+@testable
+import RxBluetoothKit
+import RxSwift
+import RxTest
+
+class BluetoothManagerTest_MonitorDisconnection: XCTestCase {
+    
+    var manager: _BluetoothManager!
+    
+    var centralManagerMock: CBCentralManagerMock!
+    var delegateWrapper: CBCentralManagerDelegateWrapperMock!
+    var peripheralDelegateProviderMock: PeripheralDelegateWrapperProviderMock!
+    var testScheduler: TestScheduler!
+    
+    let subscribeTime = TestScheduler.Defaults.subscribed
+    var disposeBag: DisposeBag!
+    
+    override func setUp() {
+        super.setUp()
+        disposeBag = DisposeBag()
+    }
+    
+    override func tearDown() {
+        disposeBag = nil
+        super.tearDown()
+    }
+    
+    func testBluetoothError() {
+        for stateWithError in _BluetoothError.invalidStateErrors {
+            let (peripheral, peripheralsObserver) = setUpMonitorDisconnection()
+            let (state, error) = stateWithError
+            
+            centralManagerMock.state = state
+
+            testScheduler.advanceTo(subscribeTime)
+            
+            XCTAssertEqual(peripheralsObserver.events.count, 2, "should get event and error for state \(state)")
+            XCTAssertTrue(peripheralsObserver.events[0].value.element!.0 === peripheral, "should get proper peripheral in next element")
+            XCTAssertNotNil(peripheralsObserver.events[0].value.element!.1, "should get proper error in next element \(error)")
+            XCTAssertTrue(peripheralsObserver.events[0].value.element!.1! is _BluetoothError, "should get proper error in next element \(error)")
+            XCTAssertEqual(peripheralsObserver.events[0].value.element!.1! as! _BluetoothError, error, "should get proper error in next element \(error)")
+            XCTAssertError(peripheralsObserver.events[1].value, error, "should get proper error \(error)")
+        }
+    }
+    
+    func testMonitorError() {
+        let (_, peripheralsObserver) = setUpMonitorDisconnection()
+        let events: [Recorded<Event<(CBPeripheralMock, Error?)>>] = [
+            error(subscribeTime + 100, TestError.error)
+        ]
+        testScheduler.createHotObservable(events).subscribe(delegateWrapper.didDisconnectPeripheral).disposed(by: disposeBag)
+        centralManagerMock.state = .poweredOn
+        
+        testScheduler.advanceTo(subscribeTime + 200)
+        
+        XCTAssertEqual(peripheralsObserver.events.count, 1, "should get only one error event")
+        XCTAssertNotNil(peripheralsObserver.events[0].value.error, "should get error")
+    }
+
+    func testDeviceDisconnectedEvent() {
+        let (peripheral, peripheralsObserver) = setUpMonitorDisconnection()
+        let events: [Recorded<Event<(CBPeripheralMock, Error?)>>] = [
+            next(subscribeTime - 100, (peripheral.peripheral, nil)),
+            next(subscribeTime + 100, (peripheral.peripheral, nil)),
+            next(subscribeTime + 101, (peripheral.peripheral, _BluetoothError.bluetoothResetting)),
+            next(subscribeTime + 102, (CBPeripheralMock(), nil)),
+        ]
+        testScheduler.createHotObservable(events).subscribe(delegateWrapper.didDisconnectPeripheral).disposed(by: disposeBag)
+        centralManagerMock.state = .poweredOn
+
+        let expectedEvents: [Recorded<Event<(_Peripheral, _BluetoothManager.DisconnectionReason?)>>] = [
+            next(subscribeTime + 100, (peripheral, nil)),
+            next(subscribeTime + 101, (peripheral, _BluetoothError.bluetoothResetting))
+        ]
+        
+        testScheduler.advanceTo(subscribeTime + 200)
+
+        testEvents(expectedEvents, peripheralsObserver)
+    }
+    
+    func testErrorAfterDeviceDisconnectedEvent() {
+        let (peripheral, peripheralsObserver) = setUpMonitorDisconnection()
+        let events: [Recorded<Event<(CBPeripheralMock, Error?)>>] = [
+            next(subscribeTime + 100, (peripheral.peripheral, nil)),
+        ]
+        testScheduler.createHotObservable(events).subscribe(delegateWrapper.didDisconnectPeripheral).disposed(by: disposeBag)
+        let stateEvents: [Recorded<Event<BluetoothState>>] = [
+            next(subscribeTime + 101, .unknown)
+        ]
+        testScheduler.createHotObservable(stateEvents).subscribe(delegateWrapper.didUpdateState).disposed(by: disposeBag)
+        centralManagerMock.state = .poweredOn
+        
+        let expectedEvents: [Recorded<Event<(_Peripheral, _BluetoothManager.DisconnectionReason?)>>] = [
+            next(subscribeTime + 100, (peripheral, nil)),
+            next(subscribeTime + 101, (peripheral, _BluetoothError(state: .unknown)))
+        ]
+        let expectedError = _BluetoothError(state: .unknown)!
+        
+        testScheduler.advanceTo(subscribeTime + 200)
+        centralManagerMock.state = .unknown
+        
+        testEvents(expectedEvents, peripheralsObserver)
+        XCTAssertError(peripheralsObserver.events[2].value, expectedError, "should receive correct error event as last event")
+    }
+    
+    // MARK: - Utils
+    
+    private func testEvents(_ expectedEvents: [Recorded<Event<(_Peripheral, _BluetoothManager.DisconnectionReason?)>>], _ peripheralsObserver: ScheduledObservable<(_Peripheral, _BluetoothManager.DisconnectionReason?)>) {
+        for eventIndex in 0...(expectedEvents.count - 2) {
+            let element = peripheralsObserver.events[eventIndex].value.element!
+            let expected = expectedEvents[eventIndex].value.element!
+            XCTAssertEqual(element.0, expected.0, "should receive same peripheral for event index \(eventIndex)")
+            if expected.1 == nil {
+                XCTAssertNil(element.1, "should receive nil error for event index \(eventIndex)")
+            } else {
+                XCTAssertEqual(element.1! as! _BluetoothError, expected.1! as! _BluetoothError, "should receive correct error for event index \(eventIndex)")
+            }
+        }
+    }
+    
+    private func setUpMonitorDisconnection() -> (_Peripheral, ScheduledObservable<(_Peripheral, _BluetoothManager.DisconnectionReason?)>) {
+        setUpProperties()
+        
+        peripheralDelegateProviderMock.provideReturns = [CBPeripheralDelegateWrapperMock()]
+        let peripheral = _Peripheral(manager: manager, peripheral: CBPeripheralMock())
+        let peripheralsObserver: ScheduledObservable<(_Peripheral, _BluetoothManager.DisconnectionReason?)> = testScheduler.scheduleObservable {
+            self.manager.monitorDisconnection(for: peripheral).asObservable()
+        }
+        return (peripheral, peripheralsObserver)
+    }
+    
+    private func setUpProperties() {
+        centralManagerMock = CBCentralManagerMock()
+        delegateWrapper = CBCentralManagerDelegateWrapperMock()
+        peripheralDelegateProviderMock = PeripheralDelegateWrapperProviderMock()
+        manager = _BluetoothManager(centralManager: centralManagerMock, delegateWrapper: delegateWrapper, peripheralDelegateProvider: peripheralDelegateProviderMock)
+        testScheduler = TestScheduler(initialClock: 0, resolution: 1.0, simulateProcessingDelay: false)
+    }
+}

--- a/Tests/BluetoothManagerTest+RetrievePeripherals.swift
+++ b/Tests/BluetoothManagerTest+RetrievePeripherals.swift
@@ -27,13 +27,9 @@ import RxTest
 import RxSwift
 import CoreBluetooth
 
-class BluetoothManagerRetrievePeripheralsTest: XCTestCase {
+class BluetoothManagerRetrievePeripheralsTest: BaseBluetoothManagerTest {
     
-    var manager: _BluetoothManager!
-    
-    var centralManagerMock: CBCentralManagerMock!
     var peripheralMock: CBPeripheralMock!
-    var peripheralDelegateProviderMock: PeripheralDelegateWrapperProviderMock!
     var testScheduler: TestScheduler!
     
     // MARK:- retrievePeripherals
@@ -114,8 +110,8 @@ class BluetoothManagerRetrievePeripheralsTest: XCTestCase {
             self.manager.retrievePeripherals(withIdentifiers: uuids).asObservable()
         }
         centralManagerMock.state = .poweredOn
-        centralManagerMock.retrievePeripheralsReturns = [[peripheralMock]]
-        peripheralDelegateProviderMock.provideReturns = [CBPeripheralDelegateWrapperMock()]
+        centralManagerMock.retrievePeripheralsReturn = [peripheralMock]
+        wrapperProviderMock.provideReturn = CBPeripheralDelegateWrapperMock()
         return (uuids, peripheralsObserver)
     }
     
@@ -127,16 +123,14 @@ class BluetoothManagerRetrievePeripheralsTest: XCTestCase {
             self.manager.retrieveConnectedPeripherals(withServices: cbUuids).asObservable()
         }
         centralManagerMock.state = .poweredOn
-        centralManagerMock.retrieveConnectedPeripheralsReturns = [[peripheralMock]]
-        peripheralDelegateProviderMock.provideReturns = [CBPeripheralDelegateWrapperMock()]
+        centralManagerMock.retrieveConnectedPeripheralsReturn = [peripheralMock]
+        wrapperProviderMock.provideReturn = CBPeripheralDelegateWrapperMock()
         return (cbUuids, peripheralsObserver)
     }
     
-    private func setUpProperties() {
+    override func setUpProperties() {
+        super.setUpProperties()
         peripheralMock = CBPeripheralMock()
-        centralManagerMock = CBCentralManagerMock()
-        peripheralDelegateProviderMock = PeripheralDelegateWrapperProviderMock()
-        manager = _BluetoothManager(centralManager: centralManagerMock, delegateWrapper: CBCentralManagerDelegateWrapperMock(), peripheralDelegateProvider: peripheralDelegateProviderMock)
         testScheduler = TestScheduler(initialClock: 0, resolution: 1.0, simulateProcessingDelay: false)
     }
 }

--- a/Tests/BluetoothManagerTest+RetrievePeripherals.swift
+++ b/Tests/BluetoothManagerTest+RetrievePeripherals.swift
@@ -58,7 +58,7 @@ class BluetoothManagerRetrievePeripheralsTest: XCTestCase {
     }
     
     func testViaIdentifiersErrorPropagationAtStart() {
-        for stateWithError in BluetoothError.invalidStateErrors {
+        for stateWithError in _BluetoothError.invalidStateErrors {
             let (_, peripheralsObserver) = setUpViaIdentifiers()
             let (state, error) = stateWithError
             
@@ -92,7 +92,7 @@ class BluetoothManagerRetrievePeripheralsTest: XCTestCase {
     }
     
     func testViaServicesUuidsErrorPropagationAtStart() {
-        for stateWithError in BluetoothError.invalidStateErrors {
+        for stateWithError in _BluetoothError.invalidStateErrors {
             let (_, peripheralsObserver) = setUpViaServicesUuids()
             let (state, error) = stateWithError
             

--- a/Tests/BluetoothManagerTest+ScanForPeripherals.swift
+++ b/Tests/BluetoothManagerTest+ScanForPeripherals.swift
@@ -1,0 +1,143 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+import RxTest
+import RxSwift
+import CoreBluetooth
+@testable
+import RxBluetoothKit
+
+class BluetoothManagerTest_ScanForPeripherals: BaseBluetoothManagerTest {
+    
+    var testScheduler: TestScheduler!
+    var disposeBag: DisposeBag!
+    let subscribeTime = TestScheduler.Defaults.subscribed
+
+    func testErrorPropagationAtStart() {
+        for stateWithError in _BluetoothError.invalidStateErrors {
+            let observer = setUpScanForPeripherals(withServices: nil, options: nil)
+            let (state, error) = stateWithError
+            
+            centralManagerMock.state = state
+            
+            testScheduler.advanceTo(subscribeTime)
+            
+            XCTAssertEqual(observer.events.count, 1, "should get error for state \(state)")
+            XCTAssertError(observer.events[0].value, error, "should get proper error \(error)")
+        }
+    }
+    
+    func testErrorPropagationAtScanInProgress() {
+        let observer = setUpScanForPeripherals(withServices: nil, options: nil)
+        centralManagerMock.state = .poweredOn
+        self.manager.scanForPeripherals(withServices: nil, options: nil).subscribe().disposed(by: disposeBag)
+        
+        testScheduler.advanceTo(subscribeTime)
+        
+        XCTAssertEqual(observer.events.count, 1, "should get ongoing error event")
+        XCTAssertError(observer.events[0].value, _BluetoothError.scanInProgress, "should get proper ongoing error event")
+    }
+    
+    func testProperScanMethodCall() {
+        let args1 = (
+            cbuuids: nil as [CBUUID]?,
+            options: nil as [String: Any]?
+        )
+        let args2 = (
+            cbuuids: [CBUUID(), CBUUID()],
+            options: ["key": "value"] as [String: Any]
+        )
+        
+        _ = setUpScanForPeripherals(withServices: args1.cbuuids, options: args1.options)
+        centralManagerMock.state = .poweredOn
+        testScheduler.advanceTo(subscribeTime)
+        
+        XCTAssertEqual(centralManagerMock.scanForPeripheralsParams.count, 1, "should call scan for peripherals")
+        XCTAssertNil(centralManagerMock.scanForPeripheralsParams[0].0, "should call with nil cbuuids")
+        XCTAssertNil(centralManagerMock.scanForPeripheralsParams[0].1, "should call with nil options")
+        
+        _ = setUpScanForPeripherals(withServices: args2.cbuuids, options: args2.options)
+        centralManagerMock.state = .poweredOn
+        testScheduler.advanceTo(subscribeTime)
+        
+        XCTAssertEqual(centralManagerMock.scanForPeripheralsParams.count, 1, "should call scan for peripherals")
+        XCTAssertEqual(centralManagerMock.scanForPeripheralsParams[0].0!, args2.cbuuids, "should call with correct cbuuids")
+        XCTAssertEqual(centralManagerMock.scanForPeripheralsParams[0].1!.count, args2.options.count, "should call with correct options")
+    }
+    
+    typealias DiscoverResult = (CBPeripheralMock, [String: Any], NSNumber)
+    func testPeripheralDiscovered() {
+        let observer = setUpScanForPeripherals(withServices: nil, options: nil)
+        centralManagerMock.state = .poweredOn
+        let peripheralMocks = [CBPeripheralMock(), CBPeripheralMock(), CBPeripheralMock()]
+        let events: [Recorded<Event<DiscoverResult>>] = [
+            next(subscribeTime - 100, (peripheralMocks[0], [:], 10)),
+            next(subscribeTime + 100, (peripheralMocks[1], [CBAdvertisementDataLocalNameKey: "value1"], 20)),
+            next(subscribeTime + 101, (peripheralMocks[2], [CBAdvertisementDataIsConnectable: true], 30)),
+            ]
+        testScheduler.createHotObservable(events).subscribe(wrapperMock.didDiscoverPeripheral).disposed(by: disposeBag)
+        
+        let expectedEvents: [Recorded<Event<_ScannedPeripheral>>] = [
+            next(subscribeTime + 100, createScannedPeripheral(peripheralMocks[1], [CBAdvertisementDataLocalNameKey: "value1"], 20)),
+            next(subscribeTime + 101, createScannedPeripheral(peripheralMocks[2], [CBAdvertisementDataIsConnectable: true], 20))
+        ]
+        
+        testScheduler.advanceTo(subscribeTime + 200)
+        
+        XCTAssertEqual(observer.events.count, 2, "should receive 2 scan events")
+        for eventIndex in 0...(expectedEvents.count - 2) {
+            let element = observer.events[eventIndex].value.element!
+            let expected = expectedEvents[eventIndex].value.element!
+            XCTAssertEqual(element.rssi, expected.rssi, "should receive correct rssi for event index \(eventIndex)")
+            XCTAssertEqual(element.peripheral, expected.peripheral, "should receive correct peripheral for event index \(eventIndex)")
+            XCTAssertEqual(element.advertisementData.localName, expected.advertisementData.localName, "should receive correct advertisement data for event index \(eventIndex)")
+            XCTAssertEqual(element.advertisementData.isConnectable, expected.advertisementData.isConnectable, "should receive correct advertisement data for event index \(eventIndex)")
+        }
+    }
+    
+    // Mark: - Utilities
+    
+    private func createScannedPeripheral(_ peripheral: CBPeripheralMock, _ advertisementData: [String: Any], _ rssi: NSNumber) -> _ScannedPeripheral {
+        return _ScannedPeripheral(
+            peripheral: _Peripheral(manager: manager, peripheral: peripheral),
+            advertisementData: AdvertisementData(advertisementData: advertisementData),
+            rssi: rssi
+        )
+    }
+    
+    private func setUpScanForPeripherals(withServices services: [CBUUID]?, options: [String: Any]?) -> ScheduledObservable<_ScannedPeripheral> {
+        setUpProperties()
+        
+        wrapperProviderMock.provideReturn = CBPeripheralDelegateWrapperMock()
+        let peripheralsObserver: ScheduledObservable<_ScannedPeripheral> = testScheduler.scheduleObservable {
+            self.manager.scanForPeripherals(withServices: services, options: options).asObservable()
+        }
+        return peripheralsObserver
+    }
+    
+    override func setUpProperties() {
+        super.setUpProperties()
+        testScheduler = TestScheduler(initialClock: 0, resolution: 1.0, simulateProcessingDelay: false)
+        disposeBag = DisposeBag()
+    }
+}

--- a/Tests/Utilities.swift
+++ b/Tests/Utilities.swift
@@ -36,6 +36,10 @@ final class Box<T> {
     }
 }
 
+enum TestError: Error {
+    case error
+}
+
 func XCTAssertError<ErrorType: Equatable, Element>(_ event: Event<Element>, _ errorType: ErrorType, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
     XCTAssertTrue(event.isStopEvent, message, file: file, line: line)
     XCTAssertNotNil(event.error, message, file: file, line: line)
@@ -121,7 +125,7 @@ extension ObservableScheduleTimes {
     }
 }
 
-extension BluetoothError {
+extension _BluetoothError {
     static var invalidStateErrors: [(CBManagerState, _BluetoothError)] {
         return [
             (.poweredOff, .bluetoothPoweredOff),


### PR DESCRIPTION
This PR is fixing 2 issues: #186 and #167 

As of #186, now if users starts new scanning when one is already ongoing it will return Error.