### PR TITLE
Changed connecting logic to handle auto disconnecting on dispose

### DIFF
--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -93,9 +93,26 @@
 		1D49C69A201B6568000610F8 /* CentralManagerTest+ObserveConnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D49C699201B6568000610F8 /* CentralManagerTest+ObserveConnect.swift */; };
 		1D49C69B201B6568000610F8 /* CentralManagerTest+ObserveConnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D49C699201B6568000610F8 /* CentralManagerTest+ObserveConnect.swift */; };
 		1D49C69C201B6568000610F8 /* CentralManagerTest+ObserveConnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D49C699201B6568000610F8 /* CentralManagerTest+ObserveConnect.swift */; };
+		1D6474DA2021D87F00A1029F /* _Connector.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6474D82021D85F00A1029F /* _Connector.generated.swift */; };
+		1D6474DB2021D88000A1029F /* _Connector.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6474D82021D85F00A1029F /* _Connector.generated.swift */; };
+		1D6474DC2021D88100A1029F /* _Connector.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6474D82021D85F00A1029F /* _Connector.generated.swift */; };
+		1D6474DE2021E31500A1029F /* ConnectorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6474DD2021E31500A1029F /* ConnectorTest.swift */; };
+		1D6474DF2021E31500A1029F /* ConnectorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6474DD2021E31500A1029F /* ConnectorTest.swift */; };
+		1D6474E02021E31500A1029F /* ConnectorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6474DD2021E31500A1029F /* ConnectorTest.swift */; };
+		1D6474E22022F83100A1029F /* ThreadSafeBoxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6474E12022F83100A1029F /* ThreadSafeBoxTest.swift */; };
+		1D6474E32022F83100A1029F /* ThreadSafeBoxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6474E12022F83100A1029F /* ThreadSafeBoxTest.swift */; };
+		1D6474E42022F83100A1029F /* ThreadSafeBoxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6474E12022F83100A1029F /* ThreadSafeBoxTest.swift */; };
 		1D8116C81FFE0F1700147BF5 /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8116C71FFE0F1700147BF5 /* Mock.generated.swift */; };
 		1D8116C91FFE0F1700147BF5 /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8116C71FFE0F1700147BF5 /* Mock.generated.swift */; };
 		1D8116CA1FFE0F1700147BF5 /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8116C71FFE0F1700147BF5 /* Mock.generated.swift */; };
+		1D9C509B202064CC006B21E4 /* Array+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9C509A202064CC006B21E4 /* Array+Utils.swift */; };
+		1D9C509C202064CC006B21E4 /* Array+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9C509A202064CC006B21E4 /* Array+Utils.swift */; };
+		1D9C509D202064CC006B21E4 /* Array+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9C509A202064CC006B21E4 /* Array+Utils.swift */; };
+		1D9C509E202064CC006B21E4 /* Array+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9C509A202064CC006B21E4 /* Array+Utils.swift */; };
+		1D9C50AF2021CC70006B21E4 /* Connector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9C50AE2021CC70006B21E4 /* Connector.swift */; };
+		1D9C50B02021CC70006B21E4 /* Connector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9C50AE2021CC70006B21E4 /* Connector.swift */; };
+		1D9C50B12021CC70006B21E4 /* Connector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9C50AE2021CC70006B21E4 /* Connector.swift */; };
+		1D9C50B22021CC70006B21E4 /* Connector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9C50AE2021CC70006B21E4 /* Connector.swift */; };
 		1DC4233F20078315009994B1 /* CBPeripheral+Uuid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC4233E20078315009994B1 /* CBPeripheral+Uuid.swift */; };
 		1DC4234020078315009994B1 /* CBPeripheral+Uuid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC4233E20078315009994B1 /* CBPeripheral+Uuid.swift */; };
 		1DC4234120078315009994B1 /* CBPeripheral+Uuid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC4233E20078315009994B1 /* CBPeripheral+Uuid.swift */; };
@@ -236,7 +253,12 @@
 		1D490B711FFF8F1D00D3F871 /* _ScanOperation.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _ScanOperation.generated.swift; sourceTree = "<group>"; };
 		1D490B751FFF8F5500D3F871 /* _RestoredState.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _RestoredState.generated.swift; sourceTree = "<group>"; };
 		1D49C699201B6568000610F8 /* CentralManagerTest+ObserveConnect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CentralManagerTest+ObserveConnect.swift"; sourceTree = "<group>"; };
+		1D6474D82021D85F00A1029F /* _Connector.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _Connector.generated.swift; sourceTree = "<group>"; };
+		1D6474DD2021E31500A1029F /* ConnectorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectorTest.swift; sourceTree = "<group>"; };
+		1D6474E12022F83100A1029F /* ThreadSafeBoxTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafeBoxTest.swift; sourceTree = "<group>"; };
 		1D8116C71FFE0F1700147BF5 /* Mock.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.generated.swift; sourceTree = "<group>"; };
+		1D9C509A202064CC006B21E4 /* Array+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Utils.swift"; sourceTree = "<group>"; };
+		1D9C50AE2021CC70006B21E4 /* Connector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connector.swift; sourceTree = "<group>"; };
 		1DC4233E20078315009994B1 /* CBPeripheral+Uuid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CBPeripheral+Uuid.swift"; sourceTree = "<group>"; };
 		1DC423442008F0EF009994B1 /* PeripheralDelegateWrapperProviderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeripheralDelegateWrapperProviderTest.swift; sourceTree = "<group>"; };
 		1DC423482008F1DB009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _PeripheralDelegateWrapperProvider.generated.swift; sourceTree = "<group>"; };
@@ -376,6 +398,7 @@
 				1DC4234D200CEDFE009994B1 /* CentralManagerTest+ObserveDisconnect.swift */,
 				1D417F87200F436900354750 /* CentralManagerTest+ScanForPeripherals.swift */,
 				1D417F8B200F877100354750 /* BaseCentralManagerTest.swift */,
+				1D6474DD2021E31500A1029F /* ConnectorTest.swift */,
 			);
 			name = CentralManager;
 			sourceTree = "<group>";
@@ -383,6 +406,7 @@
 		1D8116C61FFE0EE500147BF5 /* Autogenerated */ = {
 			isa = PBXGroup;
 			children = (
+				1D6474D82021D85F00A1029F /* _Connector.generated.swift */,
 				1D1C981A2019E8AE00DCF299 /* _CentralManager.generated.swift */,
 				1DC423482008F1DB009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift */,
 				1D490B751FFF8F5500D3F871 /* _RestoredState.generated.swift */,
@@ -412,6 +436,7 @@
 				A1299C221CBE3DEE005DEA5B /* ScanOperation.swift */,
 				A1299C0E1CBE3DEE005DEA5B /* CentralManager.swift */,
 				1D1C9827201B195000DCF299 /* CentralManager+RestoredState.swift */,
+				1D9C50AE2021CC70006B21E4 /* Connector.swift */,
 				A1299C0C1CBE3DEE005DEA5B /* AdvertisementData.swift */,
 				26F3034A1CF0D49D00D74EBF /* RestoredState.swift */,
 				26EF38C81D86EE1F00F9F468 /* BluetoothState.swift */,
@@ -431,6 +456,7 @@
 				A1299C0D1CBE3DEE005DEA5B /* BluetoothError.swift */,
 				FA947A3A1EB1C41C000ED0B1 /* UUIDIdentifiable.swift */,
 				D74B16841ED417AA006D5996 /* Logging.swift */,
+				1D9C509A202064CC006B21E4 /* Array+Utils.swift */,
 			);
 			name = Shared;
 			sourceTree = "<group>";
@@ -517,6 +543,7 @@
 				1D1BC8A220064A9E004C5F36 /* CentralManager */,
 				2666FD0A1CCE431B005E81CE /* ObservableTest+QueueSubscribeOn.swift */,
 				2666FD0B1CCE431B005E81CE /* Utilities.swift */,
+				1D6474E12022F83100A1029F /* ThreadSafeBoxTest.swift */,
 			);
 			name = Shared;
 			sourceTree = "<group>";
@@ -985,12 +1012,14 @@
 				0A7B27E31F9F1776003F950E /* Service.swift in Sources */,
 				0A7B27DA1F9F1771003F950E /* Observable+Absorb.swift in Sources */,
 				0A339D761FA1C10B008385C8 /* CBCentralManagerDelegateWrapper.swift in Sources */,
+				1D9C50B12021CC70006B21E4 /* Connector.swift in Sources */,
 				0A339D771FA1C10D008385C8 /* CBPeripheralDelegateWrapper.swift in Sources */,
 				0A7B27D81F9F1771003F950E /* Observable+QueueSubscribeOn.swift in Sources */,
 				0A7B27D51F9F176D003F950E /* CentralManager.swift in Sources */,
 				0A7B27E61F9F177A003F950E /* ScannedPeripheral.swift in Sources */,
 				0A7B27DC1F9F1771003F950E /* BluetoothError.swift in Sources */,
 				0A7B27E11F9F1773003F950E /* Characteristic.swift in Sources */,
+				1D9C509D202064CC006B21E4 /* Array+Utils.swift in Sources */,
 				0A7B27E91F9F177A003F950E /* DeviceIdentifiers.swift in Sources */,
 				0A7B27D61F9F176D003F950E /* AdvertisementData.swift in Sources */,
 				0A7B27DD1F9F1771003F950E /* UUIDIdentifiable.swift in Sources */,
@@ -1014,12 +1043,14 @@
 				0A7B282E1F9F1B33003F950E /* Logging.swift in Sources */,
 				0A7B28201F9F1B25003F950E /* DeviceIdentifiers.swift in Sources */,
 				0A339D751FA1C10A008385C8 /* CBCentralManagerDelegateWrapper.swift in Sources */,
+				1D9C50B22021CC70006B21E4 /* Connector.swift in Sources */,
 				0A7B282F1F9F1B39003F950E /* ScanOperation.swift in Sources */,
 				0A7B282C1F9F1B33003F950E /* BluetoothError.swift in Sources */,
 				0A7B281E1F9F1B25003F950E /* Peripheral.swift in Sources */,
 				0A7B282A1F9F1B33003F950E /* Observable+Absorb.swift in Sources */,
 				0A7B28211F9F1B25003F950E /* Peripheral+Convenience.swift in Sources */,
 				0A7B28341F9F1B39003F950E /* BluetoothState.swift in Sources */,
+				1D9C509E202064CC006B21E4 /* Array+Utils.swift in Sources */,
 				0A7B28231F9F1B29003F950E /* Service.swift in Sources */,
 				0A7B28271F9F1B2E003F950E /* Characteristic.swift in Sources */,
 				0A7B281B1F9F1B21003F950E /* Descriptor.swift in Sources */,
@@ -1038,8 +1069,10 @@
 			files = (
 				0A7B28131F9F1964003F950E /* ObservableTest+QueueSubscribeOn.swift in Sources */,
 				1D490B681FFF8E1200D3F871 /* _Descriptor.generated.swift in Sources */,
+				1D6474DC2021D88100A1029F /* _Connector.generated.swift in Sources */,
 				1D417F8A200F436900354750 /* CentralManagerTest+ScanForPeripherals.swift in Sources */,
 				1D490B691FFF8E1200D3F871 /* _Peripheral.generated.swift in Sources */,
+				1D6474E42022F83100A1029F /* ThreadSafeBoxTest.swift in Sources */,
 				1D490B701FFF8EBE00D3F871 /* _ScannedPeripheral.generated.swift in Sources */,
 				0A7B28141F9F1964003F950E /* Utilities.swift in Sources */,
 				1D417F8E200F877100354750 /* BaseCentralManagerTest.swift in Sources */,
@@ -1048,6 +1081,7 @@
 				1D490B781FFF8F5500D3F871 /* _RestoredState.generated.swift in Sources */,
 				1D8116CA1FFE0F1700147BF5 /* Mock.generated.swift in Sources */,
 				1D49C69C201B6568000610F8 /* CentralManagerTest+ObserveConnect.swift in Sources */,
+				1D6474E02021E31500A1029F /* ConnectorTest.swift in Sources */,
 				1D1C981E2019E8D100DCF299 /* _CentralManager.generated.swift in Sources */,
 				1D490B6A1FFF8E1200D3F871 /* _Service.generated.swift in Sources */,
 				1DC4234C2008F201009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift in Sources */,
@@ -1078,6 +1112,7 @@
 				2666FE451CCE4732005E81CE /* BluetoothError.swift in Sources */,
 				FA947A3B1EB1C41C000ED0B1 /* UUIDIdentifiable.swift in Sources */,
 				1DC4233F20078315009994B1 /* CBPeripheral+Uuid.swift in Sources */,
+				1D9C50AF2021CC70006B21E4 /* Connector.swift in Sources */,
 				1D1C9828201B195000DCF299 /* CentralManager+RestoredState.swift in Sources */,
 				2666FE3E1CCE4732005E81CE /* Characteristic.swift in Sources */,
 				2666FE321CCE4732005E81CE /* Descriptor.swift in Sources */,
@@ -1085,6 +1120,7 @@
 				2666FE421CCE4732005E81CE /* Observable+Absorb.swift in Sources */,
 				26F3034B1CF0D49D00D74EBF /* RestoredState.swift in Sources */,
 				37B64DBDA4A3B78934028507 /* PeripheralDelegateWrapperProvider.swift in Sources */,
+				1D9C509B202064CC006B21E4 /* Array+Utils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1094,8 +1130,10 @@
 			files = (
 				1D8116C81FFE0F1700147BF5 /* Mock.generated.swift in Sources */,
 				1D490B581FFF8E1000D3F871 /* _Descriptor.generated.swift in Sources */,
+				1D6474DA2021D87F00A1029F /* _Connector.generated.swift in Sources */,
 				1D417F88200F436900354750 /* CentralManagerTest+ScanForPeripherals.swift in Sources */,
 				1D490B591FFF8E1000D3F871 /* _Peripheral.generated.swift in Sources */,
+				1D6474E22022F83100A1029F /* ThreadSafeBoxTest.swift in Sources */,
 				1D490B6E1FFF8EBD00D3F871 /* _ScannedPeripheral.generated.swift in Sources */,
 				2666FDDE1CCE46E2005E81CE /* Utilities.swift in Sources */,
 				1D417F8C200F877100354750 /* BaseCentralManagerTest.swift in Sources */,
@@ -1104,6 +1142,7 @@
 				1D490B761FFF8F5500D3F871 /* _RestoredState.generated.swift in Sources */,
 				2666FDDD1CCE46E2005E81CE /* ObservableTest+QueueSubscribeOn.swift in Sources */,
 				1D49C69A201B6568000610F8 /* CentralManagerTest+ObserveConnect.swift in Sources */,
+				1D6474DE2021E31500A1029F /* ConnectorTest.swift in Sources */,
 				1D1C981C2019E8CF00DCF299 /* _CentralManager.generated.swift in Sources */,
 				1D490B5A1FFF8E1000D3F871 /* _Service.generated.swift in Sources */,
 				1DC4234A2008F1FF009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift in Sources */,
@@ -1124,12 +1163,14 @@
 				2666FE1C1CCE4731005E81CE /* DeviceIdentifiers.swift in Sources */,
 				2666FE2B1CCE4731005E81CE /* ScanOperation.swift in Sources */,
 				FA947A3C1EB1C42F000ED0B1 /* UUIDIdentifiable.swift in Sources */,
+				1D9C50B02021CC70006B21E4 /* Connector.swift in Sources */,
 				2666FE1A1CCE4731005E81CE /* Peripheral.swift in Sources */,
 				BB2FF3361F9EAF2B00A12E10 /* CBCentralManagerDelegateWrapper.swift in Sources */,
 				2666FE291CCE4731005E81CE /* Boxes.swift in Sources */,
 				2666FE1D1CCE4731005E81CE /* Peripheral+Convenience.swift in Sources */,
 				BB2FF3331F9EAF1600A12E10 /* CBPeripheralDelegateWrapper.swift in Sources */,
 				26752FA61D89C630003D8D38 /* BluetoothState.swift in Sources */,
+				1D9C509C202064CC006B21E4 /* Array+Utils.swift in Sources */,
 				2666FE1F1CCE4731005E81CE /* Service.swift in Sources */,
 				2666FE2A1CCE4731005E81CE /* BluetoothError.swift in Sources */,
 				2666FE231CCE4731005E81CE /* Characteristic.swift in Sources */,
@@ -1148,8 +1189,10 @@
 			files = (
 				1D8116C91FFE0F1700147BF5 /* Mock.generated.swift in Sources */,
 				1D490B601FFF8E1100D3F871 /* _Descriptor.generated.swift in Sources */,
+				1D6474DB2021D88000A1029F /* _Connector.generated.swift in Sources */,
 				1D417F89200F436900354750 /* CentralManagerTest+ScanForPeripherals.swift in Sources */,
 				1D490B611FFF8E1100D3F871 /* _Peripheral.generated.swift in Sources */,
+				1D6474E32022F83100A1029F /* ThreadSafeBoxTest.swift in Sources */,
 				1D490B6F1FFF8EBE00D3F871 /* _ScannedPeripheral.generated.swift in Sources */,
 				2666FDD81CCE46E1005E81CE /* Utilities.swift in Sources */,
 				1D417F8D200F877100354750 /* BaseCentralManagerTest.swift in Sources */,
@@ -1158,6 +1201,7 @@
 				1D490B771FFF8F5500D3F871 /* _RestoredState.generated.swift in Sources */,
 				2666FDD71CCE46E1005E81CE /* ObservableTest+QueueSubscribeOn.swift in Sources */,
 				1D49C69B201B6568000610F8 /* CentralManagerTest+ObserveConnect.swift in Sources */,
+				1D6474DF2021E31500A1029F /* ConnectorTest.swift in Sources */,
 				1D1C981D2019E8D000DCF299 /* _CentralManager.generated.swift in Sources */,
 				1D490B621FFF8E1100D3F871 /* _Service.generated.swift in Sources */,
 				1DC4234B2008F200009994B1 /* _PeripheralDelegateWrapperProvider.generated.swift in Sources */,

--- a/Source/Array+Utils.swift
+++ b/Source/Array+Utils.swift
@@ -21,26 +21,13 @@
 // SOFTWARE.
 
 import Foundation
-import XCTest
 
-class BaseCentralManagerTest: XCTestCase {
-    var manager: _CentralManager!
-    
-    var centralManagerMock: CBCentralManagerMock!
-    var wrapperMock: CBCentralManagerDelegateWrapperMock!
-    var wrapperProviderMock: PeripheralDelegateWrapperProviderMock!
-    var connectorMock: ConnectorMock!
-    
-    func setUpProperties() {
-        centralManagerMock = CBCentralManagerMock()
-        wrapperMock = CBCentralManagerDelegateWrapperMock()
-        wrapperProviderMock = PeripheralDelegateWrapperProviderMock()
-        connectorMock = ConnectorMock()
-        manager = _CentralManager(
-            centralManager: centralManagerMock,
-            delegateWrapper: wrapperMock,
-            peripheralDelegateProvider: wrapperProviderMock,
-            connector: connectorMock
-        )
+extension Array where Element: Equatable {
+    @discardableResult mutating func remove(object: Element) -> Bool {
+        if let index = index(of: object) {
+            self.remove(at: index)
+            return true
+        }
+        return false
     }
 }

--- a/Source/BluetoothError.swift
+++ b/Source/BluetoothError.swift
@@ -38,6 +38,8 @@ public enum BluetoothError: Error {
     case bluetoothInUnknownState
     case bluetoothResetting
     // Peripheral
+    case peripheralAlreadyConnected(Peripheral)
+    case peripheralIsConnecting(Peripheral)
     case peripheralConnectionFailed(Peripheral, Error?)
     case peripheralDisconnected(Peripheral, Error?)
     case peripheralRSSIReadFailed(Peripheral, Error?)
@@ -83,6 +85,16 @@ extension BluetoothError: CustomStringConvertible {
         case .bluetoothResetting:
             return "Bluetooth is resetting"
             // Peripheral
+        case .peripheralAlreadyConnected:
+            return """
+            Peripheral is already connected.
+            You cannot connect to peripheral when you have previously connected to it.
+            """
+        case .peripheralIsConnecting:
+            return """
+            Peripheral is already in connecting state.
+            You cannot connect to peripheral when there is ongoing connection try.
+            """
         case let .peripheralConnectionFailed(_, err):
             return "Connection error has occured: \(err?.localizedDescription ?? "-")"
         case let .peripheralDisconnected(_, err):
@@ -152,6 +164,8 @@ public func == (lhs: BluetoothError, rhs: BluetoothError) -> Bool {
     case let (.servicesDiscoveryFailed(l, _), .servicesDiscoveryFailed(r, _)): return l == r
     case let (.includedServicesDiscoveryFailed(l, _), .includedServicesDiscoveryFailed(r, _)): return l == r
         // Peripherals
+    case let (.peripheralAlreadyConnected(l), .peripheralAlreadyConnected(r)): return l == r
+    case let (.peripheralIsConnecting(l), .peripheralIsConnecting(r)): return l == r
     case let (.peripheralConnectionFailed(l, _), .peripheralConnectionFailed(r, _)): return l == r
     case let (.peripheralDisconnected(l, _), .peripheralDisconnected(r, _)): return l == r
     case let (.peripheralRSSIReadFailed(l, _), .peripheralRSSIReadFailed(r, _)): return l == r

--- a/Source/BluetoothError.swift
+++ b/Source/BluetoothError.swift
@@ -38,8 +38,7 @@ public enum BluetoothError: Error {
     case bluetoothInUnknownState
     case bluetoothResetting
     // Peripheral
-    case peripheralAlreadyConnected(Peripheral)
-    case peripheralIsConnecting(Peripheral)
+    case peripheralIsConnectingOrAlreadyConnected(Peripheral)
     case peripheralConnectionFailed(Peripheral, Error?)
     case peripheralDisconnected(Peripheral, Error?)
     case peripheralRSSIReadFailed(Peripheral, Error?)
@@ -85,15 +84,11 @@ extension BluetoothError: CustomStringConvertible {
         case .bluetoothResetting:
             return "Bluetooth is resetting"
             // Peripheral
-        case .peripheralAlreadyConnected:
+        case .peripheralIsConnectingOrAlreadyConnected:
             return """
-            Peripheral is already connected.
-            You cannot connect to peripheral when you have previously connected to it.
-            """
-        case .peripheralIsConnecting:
-            return """
-            Peripheral is already in connecting state.
-            You cannot connect to peripheral when there is ongoing connection try.
+            Peripheral is already connected or is in connecting state.
+            You cannot connect to peripheral when you have previously connected to it
+            or there is ongoing connection try.
             """
         case let .peripheralConnectionFailed(_, err):
             return "Connection error has occured: \(err?.localizedDescription ?? "-")"
@@ -164,8 +159,7 @@ public func == (lhs: BluetoothError, rhs: BluetoothError) -> Bool {
     case let (.servicesDiscoveryFailed(l, _), .servicesDiscoveryFailed(r, _)): return l == r
     case let (.includedServicesDiscoveryFailed(l, _), .includedServicesDiscoveryFailed(r, _)): return l == r
         // Peripherals
-    case let (.peripheralAlreadyConnected(l), .peripheralAlreadyConnected(r)): return l == r
-    case let (.peripheralIsConnecting(l), .peripheralIsConnecting(r)): return l == r
+    case let (.peripheralIsConnectingOrAlreadyConnected(l), .peripheralIsConnectingOrAlreadyConnected(r)): return l == r
     case let (.peripheralConnectionFailed(l, _), .peripheralConnectionFailed(r, _)): return l == r
     case let (.peripheralDisconnected(l, _), .peripheralDisconnected(r, _)): return l == r
     case let (.peripheralRSSIReadFailed(l, _), .peripheralRSSIReadFailed(r, _)): return l == r

--- a/Source/Boxes.swift
+++ b/Source/Boxes.swift
@@ -35,3 +35,47 @@ extension WeakBox {
         return "WeakBox(\(String(describing: value)))"
     }
 }
+
+/**
+ `ThreadSafeBox` is a helper class that allows use of resource (value) in a thread safe manner.
+ All read and write calls are wrapped in concurrent `DispatchQueue` which protects writing to
+ resource from more than 1 thread at a time.
+ */
+class ThreadSafeBox<T>: CustomDebugStringConvertible {
+    private let queue = DispatchQueue(label: "com.polidea.RxBluetoothKit.ThreadSafeBox", attributes: .concurrent)
+    private var value: T
+    init(value: T) {
+        self.value = value
+    }
+
+    func read<Result: Any>(_ block: (T) -> Result) -> Result {
+        var result: Result! = nil
+        queue.sync {
+            result = block(value)
+        }
+        return result
+    }
+
+    func write(_ block: @escaping (inout T) -> Void) {
+        queue.async(flags: .barrier) {
+            block(&self.value)
+        }
+    }
+
+    func compareAndSet(compare: (T) -> Bool, set: @escaping (inout T) -> Void) -> Bool {
+        var result: Bool = false
+        queue.sync {
+            result = compare(value)
+            if result {
+                write(set)
+            }
+        }
+        return result
+    }
+}
+
+extension ThreadSafeBox {
+    var debugDescription: String {
+        return "ThreadSafeBox(\(String(describing: value)))"
+    }
+}

--- a/Source/Boxes.swift
+++ b/Source/Boxes.swift
@@ -42,7 +42,7 @@ extension WeakBox {
  resource from more than 1 thread at a time.
  */
 class ThreadSafeBox<T>: CustomDebugStringConvertible {
-    private let queue = DispatchQueue(label: "com.polidea.RxBluetoothKit.ThreadSafeBox", attributes: .concurrent)
+    private let queue = DispatchQueue(label: "com.polidea.RxBluetoothKit.ThreadSafeBox")
     private var value: T
     init(value: T) {
         self.value = value
@@ -57,7 +57,7 @@ class ThreadSafeBox<T>: CustomDebugStringConvertible {
     }
 
     func write(_ block: @escaping (inout T) -> Void) {
-        queue.async(flags: .barrier) {
+        queue.async {
             block(&self.value)
         }
     }
@@ -67,7 +67,7 @@ class ThreadSafeBox<T>: CustomDebugStringConvertible {
         queue.sync {
             result = compare(value)
             if result {
-                write(set)
+                set(&self.value)
             }
         }
         return result

--- a/Source/CentralManager.swift
+++ b/Source/CentralManager.swift
@@ -197,7 +197,7 @@ public class CentralManager {
     /// The connection is automatically disconnected when resulting Observable is unsubscribed.
     /// On the other hand when the connection is interrupted or failed by the device or the system, the Observable will be unsubscribed as well
     /// following `BluetoothError.peripheralConnectionFailed` or `BluetoothError.peripheralDisconnected` emission.
-    /// Additionally you can p ass optional [dictionary](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/#//apple_ref/doc/constant_group/Peripheral_Connection_Options)
+    /// Additionally you can pass optional [dictionary](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/#//apple_ref/doc/constant_group/Peripheral_Connection_Options)
     /// to customise the behaviour of connection.
     /// - parameter peripheral: The `Peripheral` to which `CentralManager` is attempting to establish connection.
     /// - parameter options: Dictionary to customise the behaviour of connection.

--- a/Source/CentralManager.swift
+++ b/Source/CentralManager.swift
@@ -58,6 +58,9 @@ public class CentralManager {
     /// Ongoing scan disposable
     private var scanDisposable: Disposable?
 
+    /// Connector instance is used for establishing connection with peripherals
+    private let connector: Connector
+
     // MARK: Initialization
 
     /// Creates new `CentralManager`
@@ -68,11 +71,13 @@ public class CentralManager {
     init(
         centralManager: CBCentralManager,
         delegateWrapper: CBCentralManagerDelegateWrapper,
-        peripheralDelegateProvider: PeripheralDelegateWrapperProvider
+        peripheralDelegateProvider: PeripheralDelegateWrapperProvider,
+        connector: Connector
     ) {
         self.centralManager = centralManager
         self.delegateWrapper = delegateWrapper
         self.peripheralDelegateProvider = peripheralDelegateProvider
+        self.connector = connector
         centralManager.delegate = delegateWrapper
     }
 
@@ -85,10 +90,12 @@ public class CentralManager {
     public convenience init(queue: DispatchQueue = .main,
                             options: [String: AnyObject]? = nil) {
         let delegateWrapper = CBCentralManagerDelegateWrapper()
+        let centralManager = CBCentralManager(delegate: delegateWrapper, queue: queue, options: options)
         self.init(
-            centralManager: CBCentralManager(delegate: delegateWrapper, queue: queue, options: options),
+            centralManager: centralManager,
             delegateWrapper: delegateWrapper,
-            peripheralDelegateProvider: PeripheralDelegateWrapperProvider()
+            peripheralDelegateProvider: PeripheralDelegateWrapperProvider(),
+            connector: Connector(centralManager: centralManager, delegateWrapper: delegateWrapper)
         )
     }
 
@@ -185,81 +192,19 @@ public class CentralManager {
 
     // MARK: Peripheral's Connection Management
 
-    /// Establishes connection with `Peripheral` after subscription to returned observable. It's user responsibility
-    /// to close connection with `cancelConnectionToPeripheral(_:)` after subscription was completed. Unsubscribing from
-    /// returned observable cancels connection attempt. By default observable is waiting infinitely for successful connection.
+    /// Establishes connection with a given `Peripheral`.
+    /// When connection did succeded it sends event with `Peripheral` - from now on it is possible to call all other methods that require connection.
+    /// The connection is automatically disconnected when resulting Observable is unsubscribed.
+    /// On the other hand when the connection is interrupted or failed by the device or the system, the Observable will be unsubscribed as well
+    /// following `BluetoothError.peripheralConnectionFailed` or `BluetoothError.peripheralDisconnected` emission.
     /// Additionally you can pass optional [dictionary](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/#//apple_ref/doc/constant_group/Peripheral_Connection_Options)
     /// to customise the behaviour of connection.
-    /// - parameter peripheral: The `Peripheral` to which `CentralManager` is attempting to connect.
+    /// - parameter peripheral: The `Peripheral` to which `CentralManager` is attempting to establish connection.
     /// - parameter options: Dictionary to customise the behaviour of connection.
-    /// - returns: `Single` which emits next event after connection is established.
-    public func connect(_ peripheral: Peripheral, options: [String: Any]? = nil)
-        -> Single<Peripheral> {
-
-        let success = delegateWrapper.didConnectPeripheral
-            .filter { $0 == peripheral.peripheral }
-            .take(1)
-            .map { _ in return peripheral }
-
-        let error = delegateWrapper.didFailToConnectPeripheral
-            .filter { $0.0 == peripheral.peripheral }
-            .take(1)
-            .map { [weak self] (cbPeripheral, error) -> Peripheral in
-                guard let strongSelf = self else { throw BluetoothError.destroyed }
-                throw BluetoothError.peripheralConnectionFailed(Peripheral(manager: strongSelf, peripheral: cbPeripheral), error)
-            }
-
-        let observable = Observable<Peripheral>.create { [weak self] observer in
-            guard let strongSelf = self else {
-                observer.onError(BluetoothError.destroyed)
-                return Disposables.create()
-            }
-            if let error = BluetoothError(state: strongSelf.state) {
-                observer.onError(error)
-                return Disposables.create()
-            }
-
-            guard !peripheral.isConnected else {
-                observer.onNext(peripheral)
-                observer.onCompleted()
-                return Disposables.create()
-            }
-
-            let disposable = success.amb(error).subscribe(observer)
-
-            strongSelf.centralManager.connect(peripheral.peripheral, options: options)
-
-            return Disposables.create { [weak self] in
-                guard let strongSelf = self else { return }
-                if !peripheral.isConnected {
-                    strongSelf.centralManager.cancelPeripheralConnection(peripheral.peripheral)
-                    disposable.dispose()
-                }
-            }
-        }
-
-        return ensure(.poweredOn, observable: observable).asSingle()
-    }
-
-    /// Cancels an active or pending local connection to a `Peripheral` after observable subscription. It is not guaranteed
-    /// that physical connection will be closed immediately as well and all pending commands will not be executed.
-    ///
-    /// - parameter peripheral: The `Peripheral` to which the `CentralManager` is either trying to
-    /// connect or has already connected.
-    /// - returns: `Single` which emits next event when peripheral successfully cancelled connection.
-    public func cancelPeripheralConnection(_ peripheral: Peripheral) -> Single<(Peripheral)> {
-        let observable = Observable<(Peripheral, DisconnectionReason?)>.create { [weak self] observer in
-            guard let strongSelf = self else {
-                observer.onError(BluetoothError.destroyed)
-                return Disposables.create()
-            }
-            let disposable = strongSelf.observeDisconnect(for: peripheral).take(1).subscribe(observer)
-            strongSelf.centralManager.cancelPeripheralConnection(peripheral.peripheral)
-            return disposable
-        }
-      return ensure(.poweredOn, observable: observable)
-          .asSingle()
-          .map { $0.0 }
+    /// - returns: `Observable` which emits next event after connection is established.
+    public func establishConnection(_ peripheral: Peripheral, options: [String: Any]? = nil) -> Observable<Peripheral> {
+        let observable = connector.establishConnection(with: peripheral, options: options)
+        return ensure(.poweredOn, observable: observable)
     }
 
     // MARK: Retrieving Lists of Peripherals

--- a/Source/CentralManager.swift
+++ b/Source/CentralManager.swift
@@ -41,7 +41,7 @@ public typealias DisconnectionReason = Error
 ///     .flatMap { manager.scanForPeripherals(nil) }
 /// ```
 /// As a result you will receive `ScannedPeripheral` which contains `Peripheral` object, `AdvertisementData` and
-/// peripheral's RSSI registered during discovery. You can then `connectToPeripheral(_:options:)` and do other operations.
+/// peripheral's RSSI registered during discovery. You can then `establishConnection(_:options:)` and do other operations.
 /// - seealso: `Peripheral`
 public class CentralManager {
 
@@ -140,7 +140,7 @@ public class CentralManager {
     /// There can be only one ongoing scanning. It will return `BluetoothError.scanInProgress` error if
     /// this method will be called when there is already ongoing scan.
     /// As a result you will receive `ScannedPeripheral` which contains `Peripheral` object, `AdvertisementData` and
-    /// peripheral's RSSI registered during discovery. You can then `connectToPeripheral(_:options:)` and do other
+    /// peripheral's RSSI registered during discovery. You can then `establishConnection(_:options:)` and do other
     /// operations.
     /// - seealso: `Peripheral`
     ///
@@ -197,7 +197,7 @@ public class CentralManager {
     /// The connection is automatically disconnected when resulting Observable is unsubscribed.
     /// On the other hand when the connection is interrupted or failed by the device or the system, the Observable will be unsubscribed as well
     /// following `BluetoothError.peripheralConnectionFailed` or `BluetoothError.peripheralDisconnected` emission.
-    /// Additionally you can pass optional [dictionary](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/#//apple_ref/doc/constant_group/Peripheral_Connection_Options)
+    /// Additionally you can p ass optional [dictionary](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/#//apple_ref/doc/constant_group/Peripheral_Connection_Options)
     /// to customise the behaviour of connection.
     /// - parameter peripheral: The `Peripheral` to which `CentralManager` is attempting to establish connection.
     /// - parameter options: Dictionary to customise the behaviour of connection.

--- a/Source/Connector.swift
+++ b/Source/Connector.swift
@@ -94,7 +94,7 @@ class Connector {
                 compare: { !peripheral.isConnected && !$0.contains(peripheral.identifier) },
                 set: { $0.insert(peripheral.identifier) }
             )
-            
+
             guard connectionBlocked else {
                 observer.onError(BluetoothError.peripheralIsConnectingOrAlreadyConnected(peripheral))
                 return Disposables.create()

--- a/Source/Connector.swift
+++ b/Source/Connector.swift
@@ -1,0 +1,167 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import RxSwift
+import CoreBluetooth
+
+/**
+ `Connector` is a class that is responsible for establishing connection with peripherals.
+ */
+class Connector {
+    let centralManager: CBCentralManager
+    let delegateWrapper: CBCentralManagerDelegateWrapper
+    let connectingBox: ThreadSafeBox<[UUID]> = ThreadSafeBox(value: [])
+    let disconnectingBox: ThreadSafeBox<[UUID]> = ThreadSafeBox(value: [])
+
+    init(
+        centralManager: CBCentralManager,
+        delegateWrapper: CBCentralManagerDelegateWrapper
+    ) {
+        self.centralManager = centralManager
+        self.delegateWrapper = delegateWrapper
+    }
+
+    /**
+     Establishes connection with a given `Peripheral`.
+     For more information see `CentralManager.establishConnection(with:options:)`
+    */
+    func establishConnection(with peripheral: Peripheral, options: [String: Any]? = nil)
+        -> Observable<Peripheral> {
+            return .deferred { [weak self] in
+                guard let strongSelf = self else {
+                    return Observable.error(BluetoothError.destroyed)
+                }
+
+                let connectionObservable = strongSelf.createConnectionObservable(for: peripheral, options: options)
+
+                let waitForDisconnectObservable = strongSelf.delegateWrapper.didDisconnectPeripheral
+                    .filter { $0.0 == peripheral.peripheral }
+                    .take(1)
+                    .do(onNext: { [weak self] _ in
+                        guard let strongSelf = self else { return }
+                        strongSelf.disconnectingBox.write { $0.remove(object: peripheral.identifier) }
+                    })
+                    .map { _ in peripheral }
+                let isDisconnectingObservable: Observable<Peripheral> = Observable.create { observer in
+                    var isDiconnecting = strongSelf.disconnectingBox.read { $0.contains(peripheral.identifier) }
+                    let isDisconnected = peripheral.state == .disconnected
+                    // it means that peripheral is already disconnected, but we didn't update disconnecting box
+                    if isDiconnecting && isDisconnected {
+                        strongSelf.disconnectingBox.write { $0.remove(object: peripheral.identifier) }
+                        isDiconnecting = false
+                    }
+                    if !isDiconnecting {
+                        observer.onNext(peripheral)
+                    }
+                    return Disposables.create()
+                }
+                return waitForDisconnectObservable.amb(isDisconnectingObservable)
+                    .flatMap { _ in connectionObservable }
+            }
+    }
+
+    fileprivate func createConnectionObservable(
+        for peripheral: Peripheral,
+        options: [String: Any]? = nil
+    ) -> Observable<Peripheral> {
+        return Observable.create { [weak self] observer in
+            guard let strongSelf = self else {
+                observer.onError(BluetoothError.destroyed)
+                return Disposables.create()
+            }
+
+            guard !peripheral.isConnected else {
+                observer.onError(BluetoothError.peripheralAlreadyConnected(peripheral))
+                return Disposables.create()
+            }
+
+            let connectingStarted = strongSelf.connectingBox.compareAndSet(
+                compare: { !$0.contains(peripheral.identifier) },
+                set: { $0.append(peripheral.identifier) }
+            )
+            guard connectingStarted else {
+                observer.onError(BluetoothError.peripheralIsConnecting(peripheral))
+                return Disposables.create()
+            }
+
+            let connectedObservable = strongSelf.createConnectedObservable(for: peripheral)
+            let failToConnectObservable = strongSelf.createFailToConnectObservable(for: peripheral)
+            let disconnectedObservable = strongSelf.createDisconnectedObservable(for: peripheral)
+
+            let disposable = connectedObservable.amb(failToConnectObservable)
+                .do(onNext: { observer.onNext($0) })
+                .flatMap { _ in disconnectedObservable }
+                .subscribe(onError: { observer.onError($0) })
+
+            strongSelf.centralManager.connect(peripheral.peripheral, options: options)
+
+            return Disposables.create { [weak self] in
+                guard let strongSelf = self else { return }
+                disposable.dispose()
+                let isConnecting = strongSelf.connectingBox.read { $0.contains(peripheral.identifier) }
+                if isConnecting || peripheral.isConnected {
+                    strongSelf.disconnectingBox.write { $0.append(peripheral.identifier) }
+                    strongSelf.centralManager.cancelPeripheralConnection(peripheral.peripheral)
+                    strongSelf.connectingBox.write { $0.remove(object: peripheral.identifier) }
+                }
+            }
+        }
+    }
+
+    fileprivate func createConnectedObservable(for peripheral: Peripheral) -> Observable<Peripheral> {
+        return delegateWrapper.didConnectPeripheral
+            .filter { $0 == peripheral.peripheral }
+            .take(1)
+            .map { _ in peripheral }
+            .do(onNext: { [weak self] _ in
+                guard let strongSelf = self else { return }
+                strongSelf.connectingBox.write { $0.remove(object: peripheral.identifier) }
+            })
+    }
+
+    fileprivate func createDisconnectedObservable(for peripheral: Peripheral) -> Observable<Peripheral> {
+        return delegateWrapper.didDisconnectPeripheral
+            .filter { $0.0 == peripheral.peripheral }
+            .take(1)
+            .do(onNext: { [weak self] _ in
+                guard let strongSelf = self else { return }
+                strongSelf.disconnectingBox.write { $0.remove(object: peripheral.identifier) }
+            })
+            .map { (_, error) -> Peripheral in
+                throw BluetoothError.peripheralDisconnected(peripheral, error)
+            }
+    }
+
+    fileprivate func createFailToConnectObservable(for peripheral: Peripheral) -> Observable<Peripheral> {
+        return delegateWrapper.didFailToConnectPeripheral
+            .filter { $0.0 == peripheral.peripheral }
+            .take(1)
+            .do(onNext: { [weak self] _ in
+                guard let strongSelf = self else { return }
+                strongSelf.connectingBox.write { $0.remove(object: peripheral.identifier) }
+            })
+            .map { (_, error) -> Peripheral in
+                throw BluetoothError.peripheralConnectionFailed(peripheral, error)
+            }
+    }
+}

--- a/Source/Connector.swift
+++ b/Source/Connector.swift
@@ -90,12 +90,12 @@ class Connector {
                 return Disposables.create()
             }
 
-            let connectionBlocked = strongSelf.connectingBox.compareAndSet(
+            let connectingStarted = strongSelf.connectingBox.compareAndSet(
                 compare: { !peripheral.isConnected && !$0.contains(peripheral.identifier) },
                 set: { $0.insert(peripheral.identifier) }
             )
 
-            guard connectionBlocked else {
+            guard connectingStarted else {
                 observer.onError(BluetoothError.peripheralIsConnectingOrAlreadyConnected(peripheral))
                 return Disposables.create()
             }

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -100,21 +100,13 @@ public class Peripheral {
         return Observable.of(disconnected, connected).merge()
     }
 
-    /// Establishes local connection to the peripheral.
-    /// For more information look into `CentralManager.connectToPeripheral(_:options:)` because this method calls it directly.
-    /// - Parameter peripheral: The `Peripheral` to which `CentralManager` is attempting to connect.
-    /// - Parameter options: Dictionary to customise the behaviour of connection.
-    /// - Returns: `Observable` which emits next event after connection is established
-    public func connect(options: [String: AnyObject]? = nil) -> Single<Peripheral> {
-        return manager.connect(self, options: options)
-    }
-
-    /// Cancels an active or pending local connection to a `Peripheral` after observable subscription. It is not guaranteed
-    /// that physical connection will be closed immediately as well and all pending commands will not be executed.
-    ///
-    /// - returns: `Single` which emits next event when peripheral successfully cancelled connection.
-    public func cancelConnection() -> Single<Peripheral> {
-        return manager.cancelPeripheralConnection(self)
+    /// Establishes connection with a given `Peripheral`.
+    /// For more information look into `CentralManager.establishConnection(with:options:)` because this method calls it directly.
+    /// - parameter peripheral: The `Peripheral` to which `CentralManager` is attempting to connect.
+    /// - parameter options: Dictionary to customise the behaviour of connection.
+    /// - returns: `Observable` which emits next event after connection is established.
+    public func establishConnection(options: [String: AnyObject]? = nil) -> Observable<Peripheral> {
+        return manager.establishConnection(self, options: options)
     }
 
     // MARK: Services

--- a/Templates/Mock.swifttemplate
+++ b/Templates/Mock.swifttemplate
@@ -12,7 +12,8 @@ import RxSwift
     typealias MethodName = String
 
     class Utils {
-        static let classNamesToMock = ["CBCentralManager", "CBPeripheral", "CBDescriptor", "CBService", "CBCharacteristic", "CBL2CAPChannel", "CBPeer", "PeripheralDelegateWrapperProvider"]
+        static let classNamesToMock = ["CBCentralManager", "CBPeripheral", "CBDescriptor", "CBService", "CBCharacteristic", "CBL2CAPChannel", "CBPeer", "PeripheralDelegateWrapperProvider", "Connector"]
+        static let classNamesToTestable = ["Peripheral"]
         static let delegateWrapperNamesToMock = ["CBPeripheralDelegateWrapper", "CBCentralManagerDelegateWrapper"]
         static let namesToMock = classNamesToMock + delegateWrapperNamesToMock
 
@@ -51,6 +52,18 @@ import RxSwift
             return methodVariableNames
         }
 
+        static func changeTypeName(_ typeName: String) -> String {
+            var result = changeTypeNameToTestable(typeName)            
+            return changeTypeNameToMock(result)
+        }
+
+        static func changeTypeNameToTestable(_ typeName: String) -> String {
+            let regexGroup = classNamesToTestable.reduce("", { "\($0)\($1)|" }).dropLast()
+            let regex = try! NSRegularExpression(pattern: "\\b(\(regexGroup))\\b", options: NSRegularExpression.Options.caseInsensitive)
+            let range = NSMakeRange(0, typeName.characters.count)
+            return regex.stringByReplacingMatches(in: typeName, options: [], range: range, withTemplate: "_$0")
+        }
+
         static func changeTypeNameToMock(_ typeName: String) -> String {
             let regexGroup = namesToMock.reduce("", { "\($0)\($1)|" }).dropLast()
             let regex = try! NSRegularExpression(pattern: "\\b(\(regexGroup))\\b", options: NSRegularExpression.Options.caseInsensitive)
@@ -61,16 +74,16 @@ import RxSwift
         static func printVariable(_ variable: Variable, useDefaultValue: Bool = false) -> String {
             let forceUnwrap = variable.isOptional ? "" : "!"
             if let defaultValue = variable.defaultValue, useDefaultValue {
-                let changedDefaultValue = changeTypeNameToMock(defaultValue)
+                let changedDefaultValue = changeTypeName(defaultValue)
                 return "var \(variable.name) = \(changedDefaultValue)"
             } else {
-                let changedTypeName = changeTypeNameToMock(variable.typeName.name)
+                let changedTypeName = changeTypeName(variable.typeName.name)
                 return "var \(variable.name): \(changedTypeName)\(forceUnwrap)"
             }
         }
 
         static func printMethodParamTypes(_ method: SourceryRuntime.Method) -> String {
-            return method.parameters.reduce("", { "\($0)\(changeTypeNameToMock($1.typeName.name)), " }).dropLast(2)
+            return method.parameters.reduce("", { "\($0)\(changeTypeName($1.typeName.name)), " }).dropLast(2)
         }
 
         static func printMethodName(_ method: SourceryRuntime.Method, changeTypeNames: Bool = true) -> String {
@@ -81,7 +94,7 @@ import RxSwift
                 } else if (parameter.argumentLabel != nil && parameter.argumentLabel != parameter.name) {
                     labelPart = "\(parameter.argumentLabel!) "
                 }
-                var typePart = changeTypeNames ? changeTypeNameToMock(parameter.typeName.name) : parameter.typeName.name
+                var typePart = changeTypeNames ? changeTypeName(parameter.typeName.name) : parameter.typeName.name
                 var defaultPart = parameter.defaultValue != nil ? " = \(parameter.defaultValue!)" : ""
                 return "\(value)\(labelPart)\(parameter.name): \(typePart)\(defaultPart), "
             }).dropLast(2)
@@ -99,11 +112,16 @@ class <%= typeToMock.name %>Mock: NSObject {
     <%= Utils.printVariable(variable) %>
 <%      } -%>
 
-<%_     let mainInit = typeToMock.initializers.filter({ !$0.isConvenienceInitializer }).first -%>
+<%_     let mainInit = typeToMock.initializers.filter({ !$0.isConvenienceInitializer }).first
+        let convenienceInits = typeToMock.initializers.filter({ $0.isConvenienceInitializer && $0.parameters.count > 0 }) -%>
     override init() {
     }
 <%_     if mainInit != nil { -%>
     <%= Utils.printMethodName(mainInit!) %> {
+    }
+<%_     } -%>
+<%_     for convenienceInit in convenienceInits { -%>
+    <%= Utils.printMethodName(convenienceInit) %> {
     }
 <%_     } -%>
 
@@ -115,11 +133,11 @@ class <%= typeToMock.name %>Mock: NSObject {
             let methodReturnsName = "\(formattedName)Returns"
             let methodReturnName = "\(formattedName)Return"
             let isReturningType = !method.returnTypeName.isVoid 
-            let methodReturnDeclaration = isReturningType ? " -> \(Utils.changeTypeNameToMock(method.returnTypeName.name))" : "" -%>
+            let methodReturnDeclaration = isReturningType ? " -> \(Utils.changeTypeName(method.returnTypeName.name))" : "" -%>
     var <%= methodParamsName %>: [(<%= Utils.printMethodParamTypes(method) %>)] = []
 <%      if isReturningType { -%>
-    var <%= methodReturnsName %>: [<%= Utils.changeTypeNameToMock(method.returnTypeName.name) %>] = []
-    var <%= methodReturnName %>: <%= Utils.changeTypeNameToMock(method.returnTypeName.name) %>?
+    var <%= methodReturnsName %>: [<%= Utils.changeTypeName(method.returnTypeName.name) %>] = []
+    var <%= methodReturnName %>: <%= Utils.changeTypeName(method.returnTypeName.name) %>?
 <%      } -%>
     func <%= Utils.printMethodName(method) %><%= methodReturnDeclaration %> {
         <%= methodParamsName %>.append((<%= method.parameters.reduce("", { "\($0)\($1.name), " }).dropLast(2) %>))

--- a/Tests/Autogenerated/Mock.generated.swift
+++ b/Tests/Autogenerated/Mock.generated.swift
@@ -18,6 +18,8 @@ class CBCentralManagerMock: NSObject {
     }
     init(delegate: CBCentralManagerDelegate?, queue: DispatchQueue?, options: [String : Any]? = nil) {
     }
+    init(delegate: CBCentralManagerDelegate?, queue: DispatchQueue?) {
+    }
 
     var retrievePeripheralsParams: [([UUID])] = []
     var retrievePeripheralsReturns: [[CBPeripheralMock]] = []
@@ -215,6 +217,78 @@ class PeripheralDelegateWrapperProviderMock: NSObject {
             return provideReturn!
         } else {
             return provideReturns.removeFirst()
+        }
+    }
+
+}
+class ConnectorMock: NSObject {
+    var centralManager: CBCentralManagerMock!
+    var delegateWrapper: CBCentralManagerDelegateWrapperMock!
+    var connectingBox: ThreadSafeBox<[UUID]>!
+    var disconnectingBox: ThreadSafeBox<[UUID]>!
+
+    override init() {
+    }
+    init(centralManager: CBCentralManagerMock, delegateWrapper: CBCentralManagerDelegateWrapperMock) {
+    }
+
+    var establishConnectionParams: [(_Peripheral, [String: Any]?)] = []
+    var establishConnectionReturns: [Observable<_Peripheral>] = []
+    var establishConnectionReturn: Observable<_Peripheral>?
+    func establishConnection(with peripheral: _Peripheral, options: [String: Any]? = nil) -> Observable<_Peripheral> {
+        establishConnectionParams.append((peripheral, options))
+        if establishConnectionReturns.isEmpty {
+            return establishConnectionReturn!
+        } else {
+            return establishConnectionReturns.removeFirst()
+        }
+    }
+
+    var createConnectionObservableParams: [(_Peripheral, [String: Any]?)] = []
+    var createConnectionObservableReturns: [Observable<_Peripheral>] = []
+    var createConnectionObservableReturn: Observable<_Peripheral>?
+    func createConnectionObservable(for peripheral: _Peripheral, options: [String: Any]? = nil) -> Observable<_Peripheral> {
+        createConnectionObservableParams.append((peripheral, options))
+        if createConnectionObservableReturns.isEmpty {
+            return createConnectionObservableReturn!
+        } else {
+            return createConnectionObservableReturns.removeFirst()
+        }
+    }
+
+    var createConnectedObservableParams: [(_Peripheral)] = []
+    var createConnectedObservableReturns: [Observable<_Peripheral>] = []
+    var createConnectedObservableReturn: Observable<_Peripheral>?
+    func createConnectedObservable(for peripheral: _Peripheral) -> Observable<_Peripheral> {
+        createConnectedObservableParams.append((peripheral))
+        if createConnectedObservableReturns.isEmpty {
+            return createConnectedObservableReturn!
+        } else {
+            return createConnectedObservableReturns.removeFirst()
+        }
+    }
+
+    var createDisconnectedObservableParams: [(_Peripheral)] = []
+    var createDisconnectedObservableReturns: [Observable<_Peripheral>] = []
+    var createDisconnectedObservableReturn: Observable<_Peripheral>?
+    func createDisconnectedObservable(for peripheral: _Peripheral) -> Observable<_Peripheral> {
+        createDisconnectedObservableParams.append((peripheral))
+        if createDisconnectedObservableReturns.isEmpty {
+            return createDisconnectedObservableReturn!
+        } else {
+            return createDisconnectedObservableReturns.removeFirst()
+        }
+    }
+
+    var createFailToConnectObservableParams: [(_Peripheral)] = []
+    var createFailToConnectObservableReturns: [Observable<_Peripheral>] = []
+    var createFailToConnectObservableReturn: Observable<_Peripheral>?
+    func createFailToConnectObservable(for peripheral: _Peripheral) -> Observable<_Peripheral> {
+        createFailToConnectObservableParams.append((peripheral))
+        if createFailToConnectObservableReturns.isEmpty {
+            return createFailToConnectObservableReturn!
+        } else {
+            return createFailToConnectObservableReturns.removeFirst()
         }
     }
 

--- a/Tests/Autogenerated/_BluetoothError.generated.swift
+++ b/Tests/Autogenerated/_BluetoothError.generated.swift
@@ -39,6 +39,8 @@ enum _BluetoothError: Error {
     case bluetoothInUnknownState
     case bluetoothResetting
     // _Peripheral
+    case peripheralAlreadyConnected(_Peripheral)
+    case peripheralIsConnecting(_Peripheral)
     case peripheralConnectionFailed(_Peripheral, Error?)
     case peripheralDisconnected(_Peripheral, Error?)
     case peripheralRSSIReadFailed(_Peripheral, Error?)
@@ -84,6 +86,16 @@ extension _BluetoothError: CustomStringConvertible {
         case .bluetoothResetting:
             return "Bluetooth is resetting"
             // _Peripheral
+        case .peripheralAlreadyConnected:
+            return """
+            _Peripheral is already connected.
+            You cannot connect to peripheral when you have previously connected to it.
+            """
+        case .peripheralIsConnecting:
+            return """
+            _Peripheral is already in connecting state.
+            You cannot connect to peripheral when there is ongoing connection try.
+            """
         case let .peripheralConnectionFailed(_, err):
             return "Connection error has occured: \(err?.localizedDescription ?? "-")"
         case let .peripheralDisconnected(_, err):
@@ -153,6 +165,8 @@ func == (lhs: _BluetoothError, rhs: _BluetoothError) -> Bool {
     case let (.servicesDiscoveryFailed(l, _), .servicesDiscoveryFailed(r, _)): return l == r
     case let (.includedServicesDiscoveryFailed(l, _), .includedServicesDiscoveryFailed(r, _)): return l == r
         // Peripherals
+    case let (.peripheralAlreadyConnected(l), .peripheralAlreadyConnected(r)): return l == r
+    case let (.peripheralIsConnecting(l), .peripheralIsConnecting(r)): return l == r
     case let (.peripheralConnectionFailed(l, _), .peripheralConnectionFailed(r, _)): return l == r
     case let (.peripheralDisconnected(l, _), .peripheralDisconnected(r, _)): return l == r
     case let (.peripheralRSSIReadFailed(l, _), .peripheralRSSIReadFailed(r, _)): return l == r

--- a/Tests/Autogenerated/_BluetoothError.generated.swift
+++ b/Tests/Autogenerated/_BluetoothError.generated.swift
@@ -39,8 +39,7 @@ enum _BluetoothError: Error {
     case bluetoothInUnknownState
     case bluetoothResetting
     // _Peripheral
-    case peripheralAlreadyConnected(_Peripheral)
-    case peripheralIsConnecting(_Peripheral)
+    case peripheralIsConnectingOrAlreadyConnected(_Peripheral)
     case peripheralConnectionFailed(_Peripheral, Error?)
     case peripheralDisconnected(_Peripheral, Error?)
     case peripheralRSSIReadFailed(_Peripheral, Error?)
@@ -86,15 +85,11 @@ extension _BluetoothError: CustomStringConvertible {
         case .bluetoothResetting:
             return "Bluetooth is resetting"
             // _Peripheral
-        case .peripheralAlreadyConnected:
+        case .peripheralIsConnectingOrAlreadyConnected:
             return """
-            _Peripheral is already connected.
-            You cannot connect to peripheral when you have previously connected to it.
-            """
-        case .peripheralIsConnecting:
-            return """
-            _Peripheral is already in connecting state.
-            You cannot connect to peripheral when there is ongoing connection try.
+            _Peripheral is already connected or is in connecting state.
+            You cannot connect to peripheral when you have previously connected to it
+            or there is ongoing connection try.
             """
         case let .peripheralConnectionFailed(_, err):
             return "Connection error has occured: \(err?.localizedDescription ?? "-")"
@@ -165,8 +160,7 @@ func == (lhs: _BluetoothError, rhs: _BluetoothError) -> Bool {
     case let (.servicesDiscoveryFailed(l, _), .servicesDiscoveryFailed(r, _)): return l == r
     case let (.includedServicesDiscoveryFailed(l, _), .includedServicesDiscoveryFailed(r, _)): return l == r
         // Peripherals
-    case let (.peripheralAlreadyConnected(l), .peripheralAlreadyConnected(r)): return l == r
-    case let (.peripheralIsConnecting(l), .peripheralIsConnecting(r)): return l == r
+    case let (.peripheralIsConnectingOrAlreadyConnected(l), .peripheralIsConnectingOrAlreadyConnected(r)): return l == r
     case let (.peripheralConnectionFailed(l, _), .peripheralConnectionFailed(r, _)): return l == r
     case let (.peripheralDisconnected(l, _), .peripheralDisconnected(r, _)): return l == r
     case let (.peripheralRSSIReadFailed(l, _), .peripheralRSSIReadFailed(r, _)): return l == r

--- a/Tests/Autogenerated/_CentralManager.generated.swift
+++ b/Tests/Autogenerated/_CentralManager.generated.swift
@@ -198,7 +198,7 @@ class _CentralManager {
     /// The connection is automatically disconnected when resulting Observable is unsubscribed.
     /// On the other hand when the connection is interrupted or failed by the device or the system, the Observable will be unsubscribed as well
     /// following `_BluetoothError.peripheralConnectionFailed` or `_BluetoothError.peripheralDisconnected` emission.
-    /// Additionally you can p ass optional [dictionary](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/#//apple_ref/doc/constant_group/Peripheral_Connection_Options)
+    /// Additionally you can pass optional [dictionary](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/#//apple_ref/doc/constant_group/Peripheral_Connection_Options)
     /// to customise the behaviour of connection.
     /// - parameter peripheral: The `_Peripheral` to which `_CentralManager` is attempting to establish connection.
     /// - parameter options: Dictionary to customise the behaviour of connection.

--- a/Tests/Autogenerated/_CentralManager.generated.swift
+++ b/Tests/Autogenerated/_CentralManager.generated.swift
@@ -42,7 +42,7 @@ typealias DisconnectionReason = Error
 ///     .flatMap { manager.scanForPeripherals(nil) }
 /// ```
 /// As a result you will receive `_ScannedPeripheral` which contains `_Peripheral` object, `AdvertisementData` and
-/// peripheral's RSSI registered during discovery. You can then `connectToPeripheral(_:options:)` and do other operations.
+/// peripheral's RSSI registered during discovery. You can then `establishConnection(_:options:)` and do other operations.
 /// - seealso: `_Peripheral`
 class _CentralManager {
 
@@ -141,7 +141,7 @@ class _CentralManager {
     /// There can be only one ongoing scanning. It will return `_BluetoothError.scanInProgress` error if
     /// this method will be called when there is already ongoing scan.
     /// As a result you will receive `_ScannedPeripheral` which contains `_Peripheral` object, `AdvertisementData` and
-    /// peripheral's RSSI registered during discovery. You can then `connectToPeripheral(_:options:)` and do other
+    /// peripheral's RSSI registered during discovery. You can then `establishConnection(_:options:)` and do other
     /// operations.
     /// - seealso: `_Peripheral`
     ///
@@ -198,7 +198,7 @@ class _CentralManager {
     /// The connection is automatically disconnected when resulting Observable is unsubscribed.
     /// On the other hand when the connection is interrupted or failed by the device or the system, the Observable will be unsubscribed as well
     /// following `_BluetoothError.peripheralConnectionFailed` or `_BluetoothError.peripheralDisconnected` emission.
-    /// Additionally you can pass optional [dictionary](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/#//apple_ref/doc/constant_group/Peripheral_Connection_Options)
+    /// Additionally you can p ass optional [dictionary](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/#//apple_ref/doc/constant_group/Peripheral_Connection_Options)
     /// to customise the behaviour of connection.
     /// - parameter peripheral: The `_Peripheral` to which `_CentralManager` is attempting to establish connection.
     /// - parameter options: Dictionary to customise the behaviour of connection.

--- a/Tests/Autogenerated/_Connector.generated.swift
+++ b/Tests/Autogenerated/_Connector.generated.swift
@@ -91,12 +91,12 @@ class _Connector {
                 return Disposables.create()
             }
 
-            let connectionBlocked = strongSelf.connectingBox.compareAndSet(
+            let connectingStarted = strongSelf.connectingBox.compareAndSet(
                 compare: { !peripheral.isConnected && !$0.contains(peripheral.identifier) },
                 set: { $0.insert(peripheral.identifier) }
             )
 
-            guard connectionBlocked else {
+            guard connectingStarted else {
                 observer.onError(_BluetoothError.peripheralIsConnectingOrAlreadyConnected(peripheral))
                 return Disposables.create()
             }

--- a/Tests/Autogenerated/_Connector.generated.swift
+++ b/Tests/Autogenerated/_Connector.generated.swift
@@ -1,0 +1,168 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import RxSwift
+import CoreBluetooth
+@testable import RxBluetoothKit
+
+/**
+ `ConnectorMock` is a class that is responsible for establishing connection with peripherals.
+ */
+class _Connector {
+    let centralManager: CBCentralManagerMock
+    let delegateWrapper: CBCentralManagerDelegateWrapperMock
+    let connectingBox: ThreadSafeBox<[UUID]> = ThreadSafeBox(value: [])
+    let disconnectingBox: ThreadSafeBox<[UUID]> = ThreadSafeBox(value: [])
+
+    init(
+        centralManager: CBCentralManagerMock,
+        delegateWrapper: CBCentralManagerDelegateWrapperMock
+    ) {
+        self.centralManager = centralManager
+        self.delegateWrapper = delegateWrapper
+    }
+
+    /**
+     Establishes connection with a given `_Peripheral`.
+     For more information see `_CentralManager.establishConnection(with:options:)`
+    */
+    func establishConnection(with peripheral: _Peripheral, options: [String: Any]? = nil)
+        -> Observable<_Peripheral> {
+            return .deferred { [weak self] in
+                guard let strongSelf = self else {
+                    return Observable.error(_BluetoothError.destroyed)
+                }
+
+                let connectionObservable = strongSelf.createConnectionObservable(for: peripheral, options: options)
+
+                let waitForDisconnectObservable = strongSelf.delegateWrapper.didDisconnectPeripheral
+                    .filter { $0.0 == peripheral.peripheral }
+                    .take(1)
+                    .do(onNext: { [weak self] _ in
+                        guard let strongSelf = self else { return }
+                        strongSelf.disconnectingBox.write { $0.remove(object: peripheral.identifier) }
+                    })
+                    .map { _ in peripheral }
+                let isDisconnectingObservable: Observable<_Peripheral> = Observable.create { observer in
+                    var isDiconnecting = strongSelf.disconnectingBox.read { $0.contains(peripheral.identifier) }
+                    let isDisconnected = peripheral.state == .disconnected
+                    // it means that peripheral is already disconnected, but we didn't update disconnecting box
+                    if isDiconnecting && isDisconnected {
+                        strongSelf.disconnectingBox.write { $0.remove(object: peripheral.identifier) }
+                        isDiconnecting = false
+                    }
+                    if !isDiconnecting {
+                        observer.onNext(peripheral)
+                    }
+                    return Disposables.create()
+                }
+                return waitForDisconnectObservable.amb(isDisconnectingObservable)
+                    .flatMap { _ in connectionObservable }
+            }
+    }
+
+    fileprivate func createConnectionObservable(
+        for peripheral: _Peripheral,
+        options: [String: Any]? = nil
+    ) -> Observable<_Peripheral> {
+        return Observable.create { [weak self] observer in
+            guard let strongSelf = self else {
+                observer.onError(_BluetoothError.destroyed)
+                return Disposables.create()
+            }
+
+            guard !peripheral.isConnected else {
+                observer.onError(_BluetoothError.peripheralAlreadyConnected(peripheral))
+                return Disposables.create()
+            }
+
+            let connectingStarted = strongSelf.connectingBox.compareAndSet(
+                compare: { !$0.contains(peripheral.identifier) },
+                set: { $0.append(peripheral.identifier) }
+            )
+            guard connectingStarted else {
+                observer.onError(_BluetoothError.peripheralIsConnecting(peripheral))
+                return Disposables.create()
+            }
+
+            let connectedObservable = strongSelf.createConnectedObservable(for: peripheral)
+            let failToConnectObservable = strongSelf.createFailToConnectObservable(for: peripheral)
+            let disconnectedObservable = strongSelf.createDisconnectedObservable(for: peripheral)
+
+            let disposable = connectedObservable.amb(failToConnectObservable)
+                .do(onNext: { observer.onNext($0) })
+                .flatMap { _ in disconnectedObservable }
+                .subscribe(onError: { observer.onError($0) })
+
+            strongSelf.centralManager.connect(peripheral.peripheral, options: options)
+
+            return Disposables.create { [weak self] in
+                guard let strongSelf = self else { return }
+                disposable.dispose()
+                let isConnecting = strongSelf.connectingBox.read { $0.contains(peripheral.identifier) }
+                if isConnecting || peripheral.isConnected {
+                    strongSelf.disconnectingBox.write { $0.append(peripheral.identifier) }
+                    strongSelf.centralManager.cancelPeripheralConnection(peripheral.peripheral)
+                    strongSelf.connectingBox.write { $0.remove(object: peripheral.identifier) }
+                }
+            }
+        }
+    }
+
+    fileprivate func createConnectedObservable(for peripheral: _Peripheral) -> Observable<_Peripheral> {
+        return delegateWrapper.didConnectPeripheral
+            .filter { $0 == peripheral.peripheral }
+            .take(1)
+            .map { _ in peripheral }
+            .do(onNext: { [weak self] _ in
+                guard let strongSelf = self else { return }
+                strongSelf.connectingBox.write { $0.remove(object: peripheral.identifier) }
+            })
+    }
+
+    fileprivate func createDisconnectedObservable(for peripheral: _Peripheral) -> Observable<_Peripheral> {
+        return delegateWrapper.didDisconnectPeripheral
+            .filter { $0.0 == peripheral.peripheral }
+            .take(1)
+            .do(onNext: { [weak self] _ in
+                guard let strongSelf = self else { return }
+                strongSelf.disconnectingBox.write { $0.remove(object: peripheral.identifier) }
+            })
+            .map { (_, error) -> _Peripheral in
+                throw _BluetoothError.peripheralDisconnected(peripheral, error)
+            }
+    }
+
+    fileprivate func createFailToConnectObservable(for peripheral: _Peripheral) -> Observable<_Peripheral> {
+        return delegateWrapper.didFailToConnectPeripheral
+            .filter { $0.0 == peripheral.peripheral }
+            .take(1)
+            .do(onNext: { [weak self] _ in
+                guard let strongSelf = self else { return }
+                strongSelf.connectingBox.write { $0.remove(object: peripheral.identifier) }
+            })
+            .map { (_, error) -> _Peripheral in
+                throw _BluetoothError.peripheralConnectionFailed(peripheral, error)
+            }
+    }
+}

--- a/Tests/Autogenerated/_Connector.generated.swift
+++ b/Tests/Autogenerated/_Connector.generated.swift
@@ -31,8 +31,8 @@ import CoreBluetooth
 class _Connector {
     let centralManager: CBCentralManagerMock
     let delegateWrapper: CBCentralManagerDelegateWrapperMock
-    let connectingBox: ThreadSafeBox<[UUID]> = ThreadSafeBox(value: [])
-    let disconnectingBox: ThreadSafeBox<[UUID]> = ThreadSafeBox(value: [])
+    let connectingBox: ThreadSafeBox<Set<UUID>> = ThreadSafeBox(value: [])
+    let disconnectingBox: ThreadSafeBox<Set<UUID>> = ThreadSafeBox(value: [])
 
     init(
         centralManager: CBCentralManagerMock,
@@ -60,7 +60,7 @@ class _Connector {
                     .take(1)
                     .do(onNext: { [weak self] _ in
                         guard let strongSelf = self else { return }
-                        strongSelf.disconnectingBox.write { $0.remove(object: peripheral.identifier) }
+                        strongSelf.disconnectingBox.write { $0.remove(peripheral.identifier) }
                     })
                     .map { _ in peripheral }
                 let isDisconnectingObservable: Observable<_Peripheral> = Observable.create { observer in
@@ -68,7 +68,7 @@ class _Connector {
                     let isDisconnected = peripheral.state == .disconnected
                     // it means that peripheral is already disconnected, but we didn't update disconnecting box
                     if isDiconnecting && isDisconnected {
-                        strongSelf.disconnectingBox.write { $0.remove(object: peripheral.identifier) }
+                        strongSelf.disconnectingBox.write { $0.remove(peripheral.identifier) }
                         isDiconnecting = false
                     }
                     if !isDiconnecting {
@@ -91,17 +91,13 @@ class _Connector {
                 return Disposables.create()
             }
 
-            guard !peripheral.isConnected else {
-                observer.onError(_BluetoothError.peripheralAlreadyConnected(peripheral))
-                return Disposables.create()
-            }
-
-            let connectingStarted = strongSelf.connectingBox.compareAndSet(
-                compare: { !$0.contains(peripheral.identifier) },
-                set: { $0.append(peripheral.identifier) }
+            let connectionBlocked = strongSelf.connectingBox.compareAndSet(
+                compare: { !peripheral.isConnected && !$0.contains(peripheral.identifier) },
+                set: { $0.insert(peripheral.identifier) }
             )
-            guard connectingStarted else {
-                observer.onError(_BluetoothError.peripheralIsConnecting(peripheral))
+            
+            guard connectionBlocked else {
+                observer.onError(_BluetoothError.peripheralIsConnectingOrAlreadyConnected(peripheral))
                 return Disposables.create()
             }
 
@@ -121,9 +117,9 @@ class _Connector {
                 disposable.dispose()
                 let isConnecting = strongSelf.connectingBox.read { $0.contains(peripheral.identifier) }
                 if isConnecting || peripheral.isConnected {
-                    strongSelf.disconnectingBox.write { $0.append(peripheral.identifier) }
+                    strongSelf.disconnectingBox.write { $0.insert(peripheral.identifier) }
                     strongSelf.centralManager.cancelPeripheralConnection(peripheral.peripheral)
-                    strongSelf.connectingBox.write { $0.remove(object: peripheral.identifier) }
+                    strongSelf.connectingBox.write { $0.remove(peripheral.identifier) }
                 }
             }
         }
@@ -136,7 +132,7 @@ class _Connector {
             .map { _ in peripheral }
             .do(onNext: { [weak self] _ in
                 guard let strongSelf = self else { return }
-                strongSelf.connectingBox.write { $0.remove(object: peripheral.identifier) }
+                strongSelf.connectingBox.write { $0.remove(peripheral.identifier) }
             })
     }
 
@@ -146,7 +142,7 @@ class _Connector {
             .take(1)
             .do(onNext: { [weak self] _ in
                 guard let strongSelf = self else { return }
-                strongSelf.disconnectingBox.write { $0.remove(object: peripheral.identifier) }
+                strongSelf.disconnectingBox.write { $0.remove(peripheral.identifier) }
             })
             .map { (_, error) -> _Peripheral in
                 throw _BluetoothError.peripheralDisconnected(peripheral, error)
@@ -159,7 +155,7 @@ class _Connector {
             .take(1)
             .do(onNext: { [weak self] _ in
                 guard let strongSelf = self else { return }
-                strongSelf.connectingBox.write { $0.remove(object: peripheral.identifier) }
+                strongSelf.connectingBox.write { $0.remove(peripheral.identifier) }
             })
             .map { (_, error) -> _Peripheral in
                 throw _BluetoothError.peripheralConnectionFailed(peripheral, error)

--- a/Tests/Autogenerated/_Connector.generated.swift
+++ b/Tests/Autogenerated/_Connector.generated.swift
@@ -95,7 +95,7 @@ class _Connector {
                 compare: { !peripheral.isConnected && !$0.contains(peripheral.identifier) },
                 set: { $0.insert(peripheral.identifier) }
             )
-            
+
             guard connectionBlocked else {
                 observer.onError(_BluetoothError.peripheralIsConnectingOrAlreadyConnected(peripheral))
                 return Disposables.create()

--- a/Tests/Autogenerated/_Peripheral.generated.swift
+++ b/Tests/Autogenerated/_Peripheral.generated.swift
@@ -101,21 +101,13 @@ class _Peripheral {
         return Observable.of(disconnected, connected).merge()
     }
 
-    /// Establishes local connection to the peripheral.
-    /// For more information look into `_CentralManager.connectToPeripheral(_:options:)` because this method calls it directly.
-    /// - Parameter peripheral: The `_Peripheral` to which `_CentralManager` is attempting to connect.
-    /// - Parameter options: Dictionary to customise the behaviour of connection.
-    /// - Returns: `Observable` which emits next event after connection is established
-    func connect(options: [String: AnyObject]? = nil) -> Single<_Peripheral> {
-        return manager.connect(self, options: options)
-    }
-
-    /// Cancels an active or pending local connection to a `_Peripheral` after observable subscription. It is not guaranteed
-    /// that physical connection will be closed immediately as well and all pending commands will not be executed.
-    ///
-    /// - returns: `Single` which emits next event when peripheral successfully cancelled connection.
-    func cancelConnection() -> Single<_Peripheral> {
-        return manager.cancelPeripheralConnection(self)
+    /// Establishes connection with a given `_Peripheral`.
+    /// For more information look into `_CentralManager.establishConnection(with:options:)` because this method calls it directly.
+    /// - parameter peripheral: The `_Peripheral` to which `_CentralManager` is attempting to connect.
+    /// - parameter options: Dictionary to customise the behaviour of connection.
+    /// - returns: `Observable` which emits next event after connection is established.
+    func establishConnection(options: [String: AnyObject]? = nil) -> Observable<_Peripheral> {
+        return manager.establishConnection(self, options: options)
     }
 
     // MARK: Services

--- a/Tests/ConnectorTest.swift
+++ b/Tests/ConnectorTest.swift
@@ -46,7 +46,7 @@ class ConnectorTest: XCTestCase {
         testScheduler.advanceTo(subscribeTime)
         
         XCTAssertEqual(obs.events.count, 1, "should receive error event")
-        XCTAssertError(obs.events[0].value, _BluetoothError.peripheralAlreadyConnected(peripheral), "should receive correct error event")
+        XCTAssertError(obs.events[0].value, _BluetoothError.peripheralIsConnectingOrAlreadyConnected(peripheral), "should receive correct error event")
     }
     
     func testAlreadyConnectingPeripheral() {
@@ -58,7 +58,7 @@ class ConnectorTest: XCTestCase {
         testScheduler.advanceTo(subscribeTime)
         
         XCTAssertEqual(obs.events.count, 1, "should receive error event")
-        XCTAssertError(obs.events[0].value, _BluetoothError.peripheralIsConnecting(peripheral), "should receive correct error event")
+        XCTAssertError(obs.events[0].value, _BluetoothError.peripheralIsConnectingOrAlreadyConnected(peripheral), "should receive correct error event")
     }
     
     func testDisconnectingPeripheral() {
@@ -147,7 +147,7 @@ class ConnectorTest: XCTestCase {
         let (_, _, uuid) = setUpConnectableObserver()
         
         testScheduler.advanceTo(subscribeTime)
-        connector.connectingBox.write { $0.remove(object: uuid) }
+        connector.connectingBox.write { $0.remove(uuid) }
         peripheralMock.state = .connected
         testScheduler.advanceTo(disposeTime)
         
@@ -159,7 +159,7 @@ class ConnectorTest: XCTestCase {
         let (_, _, uuid) = setUpConnectableObserver()
         
         testScheduler.advanceTo(subscribeTime)
-        connector.connectingBox.write { $0.append(uuid) }
+        connector.connectingBox.write { $0.insert(uuid) }
         peripheralMock.state = .disconnected
         testScheduler.advanceTo(disposeTime)
         
@@ -171,7 +171,7 @@ class ConnectorTest: XCTestCase {
         let (_, _, uuid) = setUpConnectableObserver()
         
         testScheduler.advanceTo(subscribeTime)
-        connector.connectingBox.write { $0.remove(object: uuid) }
+        connector.connectingBox.write { $0.remove(uuid) }
         peripheralMock.state = .disconnected
         testScheduler.advanceTo(disposeTime)
         
@@ -210,8 +210,8 @@ class ConnectorTest: XCTestCase {
             centralManager: centralManagerMock,
             delegateWrapper: wrapperMock
         )
-        connector.connectingBox.write { $0.append(contentsOf: connectingUuids) }
-        connector.disconnectingBox.write { $0.append(contentsOf: disconnectingUuids) }
+        connector.connectingBox.write { $0.formUnion(connectingUuids) }
+        connector.disconnectingBox.write { $0.formUnion(disconnectingUuids) }
         testScheduler = TestScheduler(initialClock: 0, resolution: 1.0, simulateProcessingDelay: false)
         disposeBag = DisposeBag()
     }

--- a/Tests/ConnectorTest.swift
+++ b/Tests/ConnectorTest.swift
@@ -1,0 +1,218 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Polidea
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import XCTest
+import RxTest
+import RxSwift
+@testable
+import RxBluetoothKit
+
+class ConnectorTest: XCTestCase {
+    var connector: _Connector!
+    
+    var peripheralMock: CBPeripheralMock!
+    var centralManagerMock: CBCentralManagerMock!
+    var wrapperMock: CBCentralManagerDelegateWrapperMock!
+    var testScheduler: TestScheduler!
+    var disposeBag: DisposeBag!
+    let subscribeTime = TestScheduler.Defaults.subscribed
+    let disposeTime = TestScheduler.Defaults.disposed
+    
+    func testConnectedPeripheral() {
+        let (peripheral, obs) = setUpObserver(options: nil)
+        peripheralMock.uuidIdentifier = UUID()
+        peripheralMock.state = .connected
+        
+        testScheduler.advanceTo(subscribeTime)
+        
+        XCTAssertEqual(obs.events.count, 1, "should receive error event")
+        XCTAssertError(obs.events[0].value, _BluetoothError.peripheralAlreadyConnected(peripheral), "should receive correct error event")
+    }
+    
+    func testAlreadyConnectingPeripheral() {
+        let uuid = UUID()
+        let (peripheral, obs) = setUpObserver(options: nil, connectingUuids: [uuid])
+        peripheralMock.uuidIdentifier = uuid
+        peripheralMock.state = .disconnected
+        
+        testScheduler.advanceTo(subscribeTime)
+        
+        XCTAssertEqual(obs.events.count, 1, "should receive error event")
+        XCTAssertError(obs.events[0].value, _BluetoothError.peripheralIsConnecting(peripheral), "should receive correct error event")
+    }
+    
+    func testDisconnectingPeripheral() {
+        let uuid = UUID()
+        let (_, obs) = setUpObserver(options: nil, disconnectingUuids: [uuid])
+        let disconnectEvent: Recorded<Event<(CBPeripheralMock, Error?)>> = next(subscribeTime + 100, (peripheralMock, TestError.error))
+        testScheduler.createHotObservable([disconnectEvent]).subscribe(wrapperMock.didDisconnectPeripheral).disposed(by: disposeBag)
+        peripheralMock.uuidIdentifier = uuid
+        peripheralMock.state = .disconnecting
+        
+        testScheduler.advanceTo(subscribeTime)
+        
+        XCTAssertEqual(obs.events.count, 0, "should not receive anyevent when disconnecting")
+        XCTAssertFalse(connector.connectingBox.read({ $0.contains(uuid) }), "should not set peripheral as connecting")
+        XCTAssertTrue(connector.disconnectingBox.read({ $0.contains(uuid) }), "should still have peripheral as disconnecting set")
+        
+        testScheduler.advanceTo(subscribeTime + 100)
+        
+        XCTAssertTrue(connector.connectingBox.read({ $0.contains(uuid) }), "should set peripheral as connecting")
+        XCTAssertFalse(connector.disconnectingBox.read({ $0.contains(uuid) }), "should unset peripheral as disconnecting")
+        XCTAssertEqual(centralManagerMock.connectParams.count, 1, "should call connect")
+    }
+    
+    func testProperConnectCall() {
+        let (_, _) = setUpObserver(options: ["key": "value"])
+        peripheralMock.uuidIdentifier = UUID()
+        peripheralMock.state = .disconnected
+        
+        testScheduler.advanceTo(subscribeTime)
+        
+        XCTAssertEqual(centralManagerMock.connectParams.count, 1, "should call connect method")
+        XCTAssertEqual(centralManagerMock.connectParams[0].0, peripheralMock, "should call connect with proper params")
+        XCTAssertNotNil((centralManagerMock.connectParams[0].1!)["key"], "should call connect with proper params")
+        XCTAssertEqual((centralManagerMock.connectParams[0].1!)["key"] as! String, "value", "should call connect with proper params")
+    }
+    
+    func testStateChangedToConnecting() {
+        let (_, _, uuid) = setUpConnectableObserver()
+        
+        testScheduler.advanceTo(subscribeTime)
+        
+        XCTAssertTrue(connector.connectingBox.read({ $0.contains(uuid) }), "should add peripheral uuid to connecting state")
+    }
+    
+    func testConnectedEvent() {
+        let (peripheral, obs, _) = setUpConnectableObserver()
+        let connectEvent: Recorded<Event<CBPeripheralMock>> = next(subscribeTime + 100, peripheralMock)
+        let failEvent: Recorded<Event<(CBPeripheralMock, Error?)>> = next(subscribeTime + 101, (peripheralMock, nil))
+        testScheduler.createHotObservable([connectEvent]).subscribe(wrapperMock.didConnectPeripheral).disposed(by: disposeBag)
+        testScheduler.createHotObservable([failEvent]).subscribe(wrapperMock.didFailToConnectPeripheral).disposed(by: disposeBag)
+        
+        testScheduler.advanceTo(subscribeTime + 200)
+        
+        XCTAssertEqual(obs.events.count, 1, "should get connected event")
+        XCTAssertEqual(obs.events[0].value.element!, peripheral, "should get proper event element")
+    }
+    
+    func testConnectFailEvent() {
+        let (peripheral, obs, _) = setUpConnectableObserver()
+        let connectEvent: Recorded<Event<CBPeripheralMock>> = next(subscribeTime + 100, peripheralMock)
+        let failEvent: Recorded<Event<(CBPeripheralMock, Error?)>> = next(subscribeTime + 99, (peripheralMock, TestError.error))
+        testScheduler.createHotObservable([connectEvent]).subscribe(wrapperMock.didConnectPeripheral).disposed(by: disposeBag)
+        testScheduler.createHotObservable([failEvent]).subscribe(wrapperMock.didFailToConnectPeripheral).disposed(by: disposeBag)
+        
+        testScheduler.advanceTo(subscribeTime + 200)
+        
+        XCTAssertEqual(obs.events.count, 1, "should get error event")
+        XCTAssertError(obs.events[0].value, _BluetoothError.peripheralConnectionFailed(peripheral, TestError.error), "should get proper error event")
+    }
+    
+    func testDisconnectedEvent() {
+        let (peripheral, obs, _) = setUpConnectableObserver()
+        let connectEvent: Recorded<Event<CBPeripheralMock>> = next(subscribeTime + 100, peripheralMock)
+        let disconnectEvent: Recorded<Event<(CBPeripheralMock, Error?)>> = next(subscribeTime + 200, (peripheralMock, TestError.error))
+        testScheduler.createHotObservable([connectEvent]).subscribe(wrapperMock.didConnectPeripheral).disposed(by: disposeBag)
+        testScheduler.createHotObservable([disconnectEvent]).subscribe(wrapperMock.didDisconnectPeripheral).disposed(by: disposeBag)
+        
+        testScheduler.advanceTo(subscribeTime + 300)
+        
+        XCTAssertEqual(obs.events.count, 2, "should get connect and disconnect event")
+        XCTAssertEqual(obs.events[0].value.element!, peripheral, "should get proper connect event element")
+        XCTAssertError(obs.events[1].value, _BluetoothError.peripheralDisconnected(peripheral, TestError.error), "should get proper disconnect event element")
+    }
+    
+    func testCancellingConnectionWhenConnectedOnDispose() {
+        let (_, _, uuid) = setUpConnectableObserver()
+        
+        testScheduler.advanceTo(subscribeTime)
+        connector.connectingBox.write { $0.remove(object: uuid) }
+        peripheralMock.state = .connected
+        testScheduler.advanceTo(disposeTime)
+        
+        XCTAssertEqual(centralManagerMock.cancelPeripheralConnectionParams.count, 1, "should call cancel peripheral connection method")
+        XCTAssertEqual(centralManagerMock.cancelPeripheralConnectionParams[0], peripheralMock, "should call cancel peripheral connection with proper params")
+    }
+    
+    func testCancellingConnectionWhenConnectingOnDispose() {
+        let (_, _, uuid) = setUpConnectableObserver()
+        
+        testScheduler.advanceTo(subscribeTime)
+        connector.connectingBox.write { $0.append(uuid) }
+        peripheralMock.state = .disconnected
+        testScheduler.advanceTo(disposeTime)
+        
+        XCTAssertEqual(centralManagerMock.cancelPeripheralConnectionParams.count, 1, "should call cancel peripheral connection method")
+        XCTAssertEqual(centralManagerMock.cancelPeripheralConnectionParams[0], peripheralMock, "should call cancel peripheral connection with proper params")
+    }
+    
+    func testNotCancellingConnectioOnDispose() {
+        let (_, _, uuid) = setUpConnectableObserver()
+        
+        testScheduler.advanceTo(subscribeTime)
+        connector.connectingBox.write { $0.remove(object: uuid) }
+        peripheralMock.state = .disconnected
+        testScheduler.advanceTo(disposeTime)
+        
+        XCTAssertEqual(centralManagerMock.cancelPeripheralConnectionParams.count, 0, "should not call cancel peripheral connection method")
+    }
+    
+    // Mark: - Utilities
+    
+    func setUpConnectableObserver() -> (_Peripheral, ScheduledObservable<_Peripheral>, UUID) {
+        let uuid = UUID()
+        let (peripheral, obs) = setUpObserver()
+        peripheralMock.uuidIdentifier = uuid
+        peripheralMock.state = .disconnected
+        return (peripheral, obs, uuid)
+    }
+    
+    func setUpObserver(options: [String: Any]? = nil, connectingUuids: [UUID] = [], disconnectingUuids: [UUID] = [])
+        -> (_Peripheral, ScheduledObservable<_Peripheral>) {
+        setUpProperties(connectingUuids: connectingUuids, disconnectingUuids: disconnectingUuids)
+        
+        let delegateProvider = PeripheralDelegateWrapperProviderMock()
+        delegateProvider.provideReturn = CBPeripheralDelegateWrapperMock()
+        let centralManager = _CentralManager(centralManager: centralManagerMock, delegateWrapper: wrapperMock, peripheralDelegateProvider: delegateProvider, connector: ConnectorMock())
+        let peripheral = _Peripheral(manager: centralManager, peripheral: peripheralMock)
+        let observable: ScheduledObservable<_Peripheral> = testScheduler.scheduleObservable {
+            self.connector.establishConnection(with: peripheral, options: options)
+        }
+        return (peripheral, observable)
+    }
+    
+    func setUpProperties(connectingUuids: [UUID] = [], disconnectingUuids: [UUID] = []) {
+        peripheralMock = CBPeripheralMock()
+        centralManagerMock = CBCentralManagerMock()
+        wrapperMock = CBCentralManagerDelegateWrapperMock()
+        connector = _Connector(
+            centralManager: centralManagerMock,
+            delegateWrapper: wrapperMock
+        )
+        connector.connectingBox.write { $0.append(contentsOf: connectingUuids) }
+        connector.disconnectingBox.write { $0.append(contentsOf: disconnectingUuids) }
+        testScheduler = TestScheduler(initialClock: 0, resolution: 1.0, simulateProcessingDelay: false)
+        disposeBag = DisposeBag()
+    }
+}

--- a/Tests/ThreadSafeBoxTest.swift
+++ b/Tests/ThreadSafeBoxTest.swift
@@ -38,12 +38,13 @@ class ThreadSafeBoxTest: XCTestCase {
         var currentIteration = expectedIterations
         
         let expectation = XCTestExpectation(description: "Perform \(expectedIterations) iterations on concurrent threads")
+        let resultQueue = DispatchQueue(label: "com.polidea.RxBluetoothKit.ThreadSafeBoxTest")
         
         DispatchQueue.concurrentPerform(iterations: currentIteration) { index in
             let last = box.read { $0.last } ?? 0
             box.write { $0.append(last + 1) }
             
-            DispatchQueue.global().sync {
+            resultQueue.sync {
                 currentIteration -= 1
                 
                 // Final loop

--- a/scripts/generate-testable.sh
+++ b/scripts/generate-testable.sh
@@ -19,9 +19,9 @@ cd "${DIR}"
 # added import RxBluetoothKit to classes
 importblekit_pattern="s/import CoreBluetooth/&\n@testable import RxBluetoothKit/g"
 # change all occurance of CoreBluetooth classes to mock classes (e.g. CBPeripheral to CBPeripheralMock)
-mock_pattern="s/\b(CBPeripheral|CBCentralManager|CBService|CBCharacteristic|CBDescriptor|CBL2CAPChannel|CBPeer|PeripheralDelegateWrapperProvider|CBPeripheralDelegateWrapper|CBCentralManagerDelegateWrapper)\b/&Mock/g"
+mock_pattern="s/\b(CBPeripheral|CBCentralManager|CBService|CBCharacteristic|CBDescriptor|CBL2CAPChannel|CBPeer|PeripheralDelegateWrapperProvider|CBPeripheralDelegateWrapper|CBCentralManagerDelegateWrapper|Connector)\b/&Mock/g"
 # change all occurance of RxBluetoothKit classes in testable classes (e.g. change Peripheral to _Peripheral)
-testable_pattern="s/\b(Peripheral|CentralManager|Service|Characteristic|Descriptor|BluetoothError|ScannedPeripheral|ScanOperation|RestoredState|PeripheralDelegateWrapperProvider)\b/_&/g"
+testable_pattern="s/\b(Peripheral|CentralManager|Service|Characteristic|Descriptor|BluetoothError|ScannedPeripheral|ScanOperation|RestoredState|PeripheralDelegateWrapperProvider|Connector)\b/_&/g"
 # remove all public's
 removepublic_pattern="s/\bpublic \b//g"
 
@@ -44,4 +44,5 @@ create_testable_file ScannedPeripheral
 create_testable_file ScanOperation
 create_testable_file RestoredState
 create_testable_file PeripheralDelegateWrapperProvider
+create_testable_file Connector
 


### PR DESCRIPTION
Part of #173.

`CentralManager.connect` method has changed to `CentralManager.establishConnection`. Now it is a more complex method that handles:
- auto disconnecting on dispose
- waiting for disconnecting
- throwing errors when there is already connected/connecting device.

All the changes are tested and documented