### PR TITLE
Sync api for peripherals retrieval

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v7.0.2"
+github "Quick/Nimble" "v7.0.3"
 github "Quick/Quick" "v1.2.0"
-github "ReactiveX/RxSwift" "4.0.0"
+github "ReactiveX/RxSwift" "4.1.2"

--- a/README.md
+++ b/README.md
@@ -279,10 +279,12 @@ After that, it emits new element after state changes.
 Property `rx_isConnected` on `Peripheral` instance allows monitoring for changes in Peripheral connection state. Immediately after subscribtion `.next` with current state is emitted. After that, it emits new element after connection state changes.
 
 #### Retrieving Peripherals
-`BluetoothManager` also lets to retrieve peripherals in two ways:
-- via its identifier using array of `NSUUID` objects,
+`BluetoothManager` also lets to retrieve peripherals in two asynchronous ways:
+- via its identifier using array of `UUID` objects,
 - connected ones via services identifiers using array of `CBUUID` objects.
-In both cases, return type is `Observable<[Peripheral]>`, which emits .Next, and after that immediately .Complete is received.
+In both cases it returns an `Observable<[Peripheral]>` object, which emits `.next` then immediately `.complete`.
+
+You can also use the `Sync` variants to retrieve known peripherals using peripherals' identifiers (`[UUID]`) or connected ones using services' identifiers (`[CBUUID]`). Both methods returns an `[Peripheral]` object.
 
 #### Cancel connection
 Connection can be cancelled - just use `cancelConnection` method on `Peripheral`, or `BluetoothManager`.

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -308,6 +308,12 @@ public class BluetoothManager {
         return ensure(.poweredOn, observable: observable)
     }
 
+    public func retrievePeripheralsSync(withIdentifiers identifiers: [UUID]) -> [Peripheral] {
+        return centralManager.retrievePeripheralsSync(withIdentifiers: identifiers).map {
+            Peripheral(manager: self, peripheral: $0)
+        }
+    }
+
     // MARK: Internal functions
 
     /// Ensure that `state` is and will be the only state of `BluetoothManager` during subscription.

--- a/Source/BluetoothManager.swift
+++ b/Source/BluetoothManager.swift
@@ -291,6 +291,16 @@ public class BluetoothManager {
         return ensure(.poweredOn, observable: observable)
     }
 
+    /// Returns the list of the `Peripheral`s which are currently connected to the `BluetoothManager` and contain all of the specified `Service`'s UUIDs.
+    /// - parameter serviceUUIDs: A list of `Service` UUIDs
+    /// - returns: The `Peripheral`s. They are in connected state and contain all of the
+    /// `Service`s with UUIDs specified in the `serviceUUIDs` parameter.
+    public func retrieveConnectedPeripheralsSync(withServices serviceUUIDs: [CBUUID]) -> [Peripheral] {
+        return centralManager.retrieveConnectedPeripheralsSync(withServices: serviceUUIDs).map {
+            Peripheral(manager: self, peripheral: $0)
+        }
+    }
+
     /// Returns observable list of `Peripheral`s by their identifiers which are known to `BluetoothManager`.
     /// - parameter identifiers: List of `Peripheral`'s identifiers which should be retrieved.
     /// - returns: Observable which emits next and complete events when list of `Peripheral`s are retrieved.
@@ -308,6 +318,9 @@ public class BluetoothManager {
         return ensure(.poweredOn, observable: observable)
     }
 
+    /// Returns the list of `Peripheral`s by their identifiers which are known to `BluetoothManager`.
+    /// - parameter identifiers: List of `Peripheral`'s identifiers which should be retrieved.
+    /// - returns: The list of known `Peripheral`s that match the given identifiers.
     public func retrievePeripheralsSync(withIdentifiers identifiers: [UUID]) -> [Peripheral] {
         return centralManager.retrievePeripheralsSync(withIdentifiers: identifiers).map {
             Peripheral(manager: self, peripheral: $0)

--- a/Source/RxCBCentralManager.swift
+++ b/Source/RxCBCentralManager.swift
@@ -167,6 +167,14 @@ class RxCBCentralManager: RxCentralManagerType {
                             \(centralManager.logDescription) retrievePeripherals(
                             withIdentifiers: \(identifiers.logDescription))
                             """)
-        return .just(centralManager.retrievePeripherals(withIdentifiers: identifiers).map(RxCBPeripheral.init))
+        return .just(retrievePeripheralsSync(withIdentifiers: identifiers))
+    }
+
+    func retrievePeripheralsSync(withIdentifiers identifiers: [UUID]) -> [RxPeripheralType] {
+        RxBluetoothKitLog.d("""
+                            \(centralManager.logDescription) retrievePeripheralsSync(
+                            withIdentifiers: \(identifiers.logDescription))
+                            """)
+        return centralManager.retrievePeripherals(withIdentifiers: identifiers).map(RxCBPeripheral.init)
     }
 }

--- a/Source/RxCBCentralManager.swift
+++ b/Source/RxCBCentralManager.swift
@@ -159,7 +159,15 @@ class RxCBCentralManager: RxCentralManagerType {
                             \(centralManager.logDescription) retrieveConnectedPeripherals(
                             withServices: \(serviceUUIDs.logDescription))
                             """)
-        return .just(centralManager.retrieveConnectedPeripherals(withServices: serviceUUIDs).map(RxCBPeripheral.init))
+        return .just(retrieveConnectedPeripheralsSync(withServices: serviceUUIDs))
+    }
+
+    func retrieveConnectedPeripheralsSync(withServices serviceUUIDs: [CBUUID]) -> [RxPeripheralType] {
+        RxBluetoothKitLog.d("""
+                            \(centralManager.logDescription) retrieveConnectedPeripheralsSync(
+                            withServices: \(serviceUUIDs.logDescription))
+                            """)
+        return centralManager.retrieveConnectedPeripherals(withServices: serviceUUIDs).map(RxCBPeripheral.init)
     }
 
     func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> Observable<[RxPeripheralType]> {

--- a/Source/RxCentralManagerType.swift
+++ b/Source/RxCentralManagerType.swift
@@ -42,6 +42,7 @@ protocol RxCentralManagerType {
     func cancelPeripheralConnection(_ peripheral: RxPeripheralType)
     func stopScan()
     func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBUUID]) -> Observable<[RxPeripheralType]>
+    func retrieveConnectedPeripheralsSync(withServices serviceUUIDs: [CBUUID]) -> [RxPeripheralType]
     func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> Observable<[RxPeripheralType]>
     func retrievePeripheralsSync(withIdentifiers identifiers: [UUID]) -> [RxPeripheralType]
 }

--- a/Source/RxCentralManagerType.swift
+++ b/Source/RxCentralManagerType.swift
@@ -43,4 +43,5 @@ protocol RxCentralManagerType {
     func stopScan()
     func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBUUID]) -> Observable<[RxPeripheralType]>
     func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> Observable<[RxPeripheralType]>
+    func retrievePeripheralsSync(withIdentifiers identifiers: [UUID]) -> [RxPeripheralType]
 }

--- a/Tests/BluetoothManagerSpec.swift
+++ b/Tests/BluetoothManagerSpec.swift
@@ -47,6 +47,17 @@ class BluetoothManagerSpec: QuickSpec {
             nextTime = 230
             errorTime = 240
         }
+        
+        describe("retrieving peripherals sync") {
+            context("via identifiers") {
+                it("should retrieve the correct peripherals") {
+                    let expected: [RxPeripheralType] = [fakePeripheral]
+                    fakeCentralManager.retrievePeripheralsSyncWithIdentifiersResult = expected
+                    let peripherals = manager.retrievePeripheralsSync(withIdentifiers: [UUID()])
+                    expect(peripherals.map { $0.identifier }).to(equal(expected.map { $0.identifier }))
+                }
+            }
+        }
 
         describe("retrieving peripherals") {
 
@@ -57,8 +68,8 @@ class BluetoothManagerSpec: QuickSpec {
 
                 beforeEach {
                     uuids = [UUID(), UUID()]
-                    fakeCentralManager.retrievePeripheralsWithIdentifiersTO = testScheduler.createObserver([UUID].self)
-                    retrieveWithIdentifiersCallObserver = fakeCentralManager.retrievePeripheralsWithIdentifiersTO
+                    retrieveWithIdentifiersCallObserver = testScheduler.createObserver([UUID].self)
+                    fakeCentralManager.retrievePeripheralsWithIdentifiersTO = retrieveWithIdentifiersCallObserver
                     peripheralsObserver = testScheduler.scheduleObservable {
                         manager.retrievePeripherals(withIdentifiers: uuids)
                     }

--- a/Tests/BluetoothManagerSpec.swift
+++ b/Tests/BluetoothManagerSpec.swift
@@ -57,6 +57,15 @@ class BluetoothManagerSpec: QuickSpec {
                     expect(peripherals.map { $0.identifier }).to(equal(expected.map { $0.identifier }))
                 }
             }
+            
+            context("connected via services identifiers") {
+                it("should retrieve the connected peripherals") {
+                    let expected: [RxPeripheralType] = [fakePeripheral]
+                    fakeCentralManager.retrieveConnectedPeripheralsSyncWithServicesResult = expected
+                    let peripherals = manager.retrieveConnectedPeripheralsSync(withServices: [CBUUID()])
+                    expect(peripherals.map { $0.identifier }).to(equal(expected.map { $0.identifier }))
+                }
+            }
         }
 
         describe("retrieving peripherals") {

--- a/Tests/FakeCentralManager.swift
+++ b/Tests/FakeCentralManager.swift
@@ -71,6 +71,11 @@ class FakeCentralManager: RxCentralManagerType {
         return retrieveConnectedPeripheralsWithServicesResult
     }
 
+    var retrieveConnectedPeripheralsSyncWithServicesResult: [RxPeripheralType]?
+    func retrieveConnectedPeripheralsSync(withServices serviceUUIDs: [CBUUID]) -> [RxPeripheralType] {
+        return retrieveConnectedPeripheralsSyncWithServicesResult ?? []
+    }
+
     var retrievePeripheralsWithIdentifiersTO: TestableObserver<[UUID]>?
     var retrievePeripheralsWithIdentifiersResult: Observable<[RxPeripheralType]> = .never()
     func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> Observable<[RxPeripheralType]> {

--- a/Tests/FakeCentralManager.swift
+++ b/Tests/FakeCentralManager.swift
@@ -77,4 +77,9 @@ class FakeCentralManager: RxCentralManagerType {
         retrievePeripheralsWithIdentifiersTO?.onNext(identifiers)
         return retrievePeripheralsWithIdentifiersResult
     }
+    
+    var retrievePeripheralsSyncWithIdentifiersResult: [RxPeripheralType]?
+    func retrievePeripheralsSync(withIdentifiers identifiers: [UUID]) -> [RxPeripheralType] {
+        return retrievePeripheralsSyncWithIdentifiersResult ?? []
+    }
 }


### PR DESCRIPTION
I added methods to retrieve peripherals (known or connected) in a synchronous way.

Let me know if this is fine. I'm happy to hear your feedbacks ! 😉 