### PR TITLE
Characteristics state changes can now be observed

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "4.1.0"
+github "ReactiveX/RxSwift" "4.1.2"

--- a/Source/BluetoothError.swift
+++ b/Source/BluetoothError.swift
@@ -28,6 +28,7 @@ public enum BluetoothError: Error {
     case characteristicWriteFailed(Characteristic, Error?)
     case characteristicReadFailed(Characteristic, Error?)
     case characteristicNotifyChangeFailed(Characteristic, Error?)
+    case characteristicStateChangedFailed(Characteristic, Error?)
     // Descriptors
     case descriptorsDiscoveryFailed(Characteristic, Error?)
     case descriptorWriteFailed(Descriptor, Error?)
@@ -61,7 +62,7 @@ extension BluetoothError: CustomStringConvertible {
             return "Bluetooth is in unknown state"
         case .bluetoothResetting:
             return "Bluetooth is resetting"
-            // Peripheral
+        // Peripheral
         case .peripheralIsConnectingOrAlreadyConnected:
             return """
             Peripheral is already connected or is in connecting state.
@@ -74,12 +75,12 @@ extension BluetoothError: CustomStringConvertible {
             return "Connection error has occured: \(err?.localizedDescription ?? "-")"
         case let .peripheralRSSIReadFailed(_, err):
             return "RSSI read failed : \(err?.localizedDescription ?? "-")"
-            // Services
+        // Services
         case let .servicesDiscoveryFailed(_, err):
             return "Services discovery error has occured: \(err?.localizedDescription ?? "-")"
         case let .includedServicesDiscoveryFailed(_, err):
             return "Included services discovery error has occured: \(err?.localizedDescription ?? "-")"
-            // Characteristics
+        // Characteristics
         case let .characteristicsDiscoveryFailed(_, err):
             return "Characteristics discovery error has occured: \(err?.localizedDescription ?? "-")"
         case let .characteristicWriteFailed(_, err):
@@ -88,7 +89,9 @@ extension BluetoothError: CustomStringConvertible {
             return "Characteristic read error has occured: \(err?.localizedDescription ?? "-")"
         case let .characteristicNotifyChangeFailed(_, err):
             return "Characteristic notify change error has occured: \(err?.localizedDescription ?? "-")"
-            // Descriptors
+        case let .characteristicStateChangedFailed(_, err):
+            return "Characteristic state change error has occured: \(err?.localizedDescription ?? "-")"
+        // Descriptors
         case let .descriptorsDiscoveryFailed(_, err):
             return "Descriptor discovery error has occured: \(err?.localizedDescription ?? "-")"
         case let .descriptorWriteFailed(_, err):
@@ -133,20 +136,21 @@ public func == (lhs: BluetoothError, rhs: BluetoothError) -> Bool {
     case (.bluetoothPoweredOff, .bluetoothPoweredOff): return true
     case (.bluetoothInUnknownState, .bluetoothInUnknownState): return true
     case (.bluetoothResetting, .bluetoothResetting): return true
-        // Services
+    // Services
     case let (.servicesDiscoveryFailed(l, _), .servicesDiscoveryFailed(r, _)): return l == r
     case let (.includedServicesDiscoveryFailed(l, _), .includedServicesDiscoveryFailed(r, _)): return l == r
-        // Peripherals
+    // Peripherals
     case let (.peripheralIsConnectingOrAlreadyConnected(l), .peripheralIsConnectingOrAlreadyConnected(r)): return l == r
     case let (.peripheralConnectionFailed(l, _), .peripheralConnectionFailed(r, _)): return l == r
     case let (.peripheralDisconnected(l, _), .peripheralDisconnected(r, _)): return l == r
     case let (.peripheralRSSIReadFailed(l, _), .peripheralRSSIReadFailed(r, _)): return l == r
-        // Characteristics
+    // Characteristics
     case let (.characteristicsDiscoveryFailed(l, _), .characteristicsDiscoveryFailed(r, _)): return l == r
     case let (.characteristicWriteFailed(l, _), .characteristicWriteFailed(r, _)): return l == r
     case let (.characteristicReadFailed(l, _), .characteristicReadFailed(r, _)): return l == r
     case let (.characteristicNotifyChangeFailed(l, _), .characteristicNotifyChangeFailed(r, _)): return l == r
-        // Descriptors
+    case let (.characteristicStateChangedFailed(l, _), .characteristicStateChangedFailed(r, _)): return l == r
+    // Descriptors
     case let (.descriptorsDiscoveryFailed(l, _), .descriptorsDiscoveryFailed(r, _)): return l == r
     case let (.descriptorWriteFailed(l, _), .descriptorWriteFailed(r, _)): return l == r
     case let (.descriptorReadFailed(l, _), .descriptorReadFailed(r, _)): return l == r

--- a/Source/BluetoothError.swift
+++ b/Source/BluetoothError.swift
@@ -28,7 +28,7 @@ public enum BluetoothError: Error {
     case characteristicWriteFailed(Characteristic, Error?)
     case characteristicReadFailed(Characteristic, Error?)
     case characteristicNotifyChangeFailed(Characteristic, Error?)
-    case characteristicStateChangedFailed(Characteristic, Error?)
+    case characteristicSetNotifyValueFailed(Characteristic, Error?)
     // Descriptors
     case descriptorsDiscoveryFailed(Characteristic, Error?)
     case descriptorWriteFailed(Descriptor, Error?)
@@ -89,8 +89,8 @@ extension BluetoothError: CustomStringConvertible {
             return "Characteristic read error has occured: \(err?.localizedDescription ?? "-")"
         case let .characteristicNotifyChangeFailed(_, err):
             return "Characteristic notify change error has occured: \(err?.localizedDescription ?? "-")"
-        case let .characteristicStateChangedFailed(_, err):
-            return "Characteristic state change error has occured: \(err?.localizedDescription ?? "-")"
+        case let .characteristicSetNotifyValueFailed(_, err):
+            return "Characteristic isNotyfing value change error has occured: \(err?.localizedDescription ?? "-")"
         // Descriptors
         case let .descriptorsDiscoveryFailed(_, err):
             return "Descriptor discovery error has occured: \(err?.localizedDescription ?? "-")"
@@ -149,7 +149,7 @@ public func == (lhs: BluetoothError, rhs: BluetoothError) -> Bool {
     case let (.characteristicWriteFailed(l, _), .characteristicWriteFailed(r, _)): return l == r
     case let (.characteristicReadFailed(l, _), .characteristicReadFailed(r, _)): return l == r
     case let (.characteristicNotifyChangeFailed(l, _), .characteristicNotifyChangeFailed(r, _)): return l == r
-    case let (.characteristicStateChangedFailed(l, _), .characteristicStateChangedFailed(r, _)): return l == r
+    case let (.characteristicSetNotifyValueFailed(l, _), .characteristicSetNotifyValueFailed(r, _)): return l == r
     // Descriptors
     case let (.descriptorsDiscoveryFailed(l, _), .descriptorsDiscoveryFailed(r, _)): return l == r
     case let (.descriptorWriteFailed(l, _), .descriptorWriteFailed(r, _)): return l == r

--- a/Source/Characteristic.swift
+++ b/Source/Characteristic.swift
@@ -60,6 +60,13 @@ public class Characteristic {
         return service.peripheral.observeWrite(for: self)
     }
 
+    /// Function that allows to know the exact time, when isNotyfing value has changed on a characteristic.
+    ///
+    /// - returns: `Observable` emitting `Characteristic` when isNoytfing value has changed.
+    public func observeNotifyValue() -> Observable<Characteristic> {
+        return service.peripheral.observeNotifyValue(for: self)
+    }
+
     /// Function that triggers write of data to characteristic. Write is called after subscribtion to `Observable` is made.
     /// Behavior of this function strongly depends on [CBCharacteristicWriteType](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBPeripheral_Class/#//apple_ref/swift/enum/c:@E@CBCharacteristicWriteType), so be sure to check this out before usage of the method.
     /// - parameter data: `Data` that'll be written to the `Characteristic`

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -346,7 +346,11 @@ public class Peripheral {
         let observable = notificationManager.observeValueUpdateAndSetNotification(for: characteristic)
         return ensureValidPeripheralState(for: observable)
     }
-
+    
+    /// Use this function in order to know the exact time, when isNotyfing value has changed on a Characteristic.
+    ///
+    /// - parameter characteristic: `Characteristic` which you observe for isNotyfing changes.
+    /// - returns: `Observable` emitting `Characteristic` when given characteristic has changed it's isNoytfing value.
     public func observeNotifyValue(for characteristic: Characteristic) -> Observable<Characteristic> {
         return delegateWrapper.peripheralDidUpdateNotificationStateForCharacteristic
             .filter { $0.0 == characteristic.characteristic }

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -347,6 +347,19 @@ public class Peripheral {
         return ensureValidPeripheralState(for: observable)
     }
 
+    public func observeCharacteristicStateChanged(for characteristic: Characteristic) -> Observable<Characteristic> {
+        return delegateWrapper.peripheralDidUpdateNotificationStateForCharacteristic
+            .filter { $0.0 == characteristic.characteristic }
+            .map { [weak self] (cbCharacteristic, error) -> Characteristic in
+                guard let strongSelf = self else { throw BluetoothError.destroyed }
+                let characteristic = Characteristic(characteristic: cbCharacteristic, peripheral: strongSelf)
+                if let error = error {
+                    throw BluetoothError.characteristicStateChangedFailed(characteristic, error)
+                }
+                return characteristic
+        }
+    }
+
     // MARK: Descriptors
 
     /// Function that triggers descriptors discovery for characteristic

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -347,7 +347,7 @@ public class Peripheral {
         return ensureValidPeripheralState(for: observable)
     }
 
-    public func observeCharacteristicStateChanged(for characteristic: Characteristic) -> Observable<Characteristic> {
+    public func observeNotifyValue(for characteristic: Characteristic) -> Observable<Characteristic> {
         return delegateWrapper.peripheralDidUpdateNotificationStateForCharacteristic
             .filter { $0.0 == characteristic.characteristic }
             .map { [weak self] (cbCharacteristic, error) -> Characteristic in

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -346,7 +346,7 @@ public class Peripheral {
         let observable = notificationManager.observeValueUpdateAndSetNotification(for: characteristic)
         return ensureValidPeripheralState(for: observable)
     }
-    
+
     /// Use this function in order to know the exact time, when isNotyfing value has changed on a Characteristic.
     ///
     /// - parameter characteristic: `Characteristic` which you observe for isNotyfing changes.
@@ -358,7 +358,7 @@ public class Peripheral {
                 guard let strongSelf = self else { throw BluetoothError.destroyed }
                 let characteristic = Characteristic(characteristic: cbCharacteristic, peripheral: strongSelf)
                 if let error = error {
-                    throw BluetoothError.characteristicStateChangedFailed(characteristic, error)
+                    throw BluetoothError.characteristicSetNotifyValueFailed(characteristic, error)
                 }
                 return characteristic
         }

--- a/Tests/Autogenerated/_BluetoothError.generated.swift
+++ b/Tests/Autogenerated/_BluetoothError.generated.swift
@@ -29,6 +29,7 @@ enum _BluetoothError: Error {
     case characteristicWriteFailed(_Characteristic, Error?)
     case characteristicReadFailed(_Characteristic, Error?)
     case characteristicNotifyChangeFailed(_Characteristic, Error?)
+    case characteristicStateChangedFailed(_Characteristic, Error?)
     // Descriptors
     case descriptorsDiscoveryFailed(_Characteristic, Error?)
     case descriptorWriteFailed(_Descriptor, Error?)
@@ -62,7 +63,7 @@ extension _BluetoothError: CustomStringConvertible {
             return "Bluetooth is in unknown state"
         case .bluetoothResetting:
             return "Bluetooth is resetting"
-            // _Peripheral
+        // _Peripheral
         case .peripheralIsConnectingOrAlreadyConnected:
             return """
             _Peripheral is already connected or is in connecting state.
@@ -75,12 +76,12 @@ extension _BluetoothError: CustomStringConvertible {
             return "Connection error has occured: \(err?.localizedDescription ?? "-")"
         case let .peripheralRSSIReadFailed(_, err):
             return "RSSI read failed : \(err?.localizedDescription ?? "-")"
-            // Services
+        // Services
         case let .servicesDiscoveryFailed(_, err):
             return "Services discovery error has occured: \(err?.localizedDescription ?? "-")"
         case let .includedServicesDiscoveryFailed(_, err):
             return "Included services discovery error has occured: \(err?.localizedDescription ?? "-")"
-            // Characteristics
+        // Characteristics
         case let .characteristicsDiscoveryFailed(_, err):
             return "Characteristics discovery error has occured: \(err?.localizedDescription ?? "-")"
         case let .characteristicWriteFailed(_, err):
@@ -89,7 +90,9 @@ extension _BluetoothError: CustomStringConvertible {
             return "_Characteristic read error has occured: \(err?.localizedDescription ?? "-")"
         case let .characteristicNotifyChangeFailed(_, err):
             return "_Characteristic notify change error has occured: \(err?.localizedDescription ?? "-")"
-            // Descriptors
+        case let .characteristicStateChangedFailed(_, err):
+            return "_Characteristic state change error has occured: \(err?.localizedDescription ?? "-")"
+        // Descriptors
         case let .descriptorsDiscoveryFailed(_, err):
             return "_Descriptor discovery error has occured: \(err?.localizedDescription ?? "-")"
         case let .descriptorWriteFailed(_, err):
@@ -134,20 +137,21 @@ func == (lhs: _BluetoothError, rhs: _BluetoothError) -> Bool {
     case (.bluetoothPoweredOff, .bluetoothPoweredOff): return true
     case (.bluetoothInUnknownState, .bluetoothInUnknownState): return true
     case (.bluetoothResetting, .bluetoothResetting): return true
-        // Services
+    // Services
     case let (.servicesDiscoveryFailed(l, _), .servicesDiscoveryFailed(r, _)): return l == r
     case let (.includedServicesDiscoveryFailed(l, _), .includedServicesDiscoveryFailed(r, _)): return l == r
-        // Peripherals
+    // Peripherals
     case let (.peripheralIsConnectingOrAlreadyConnected(l), .peripheralIsConnectingOrAlreadyConnected(r)): return l == r
     case let (.peripheralConnectionFailed(l, _), .peripheralConnectionFailed(r, _)): return l == r
     case let (.peripheralDisconnected(l, _), .peripheralDisconnected(r, _)): return l == r
     case let (.peripheralRSSIReadFailed(l, _), .peripheralRSSIReadFailed(r, _)): return l == r
-        // Characteristics
+    // Characteristics
     case let (.characteristicsDiscoveryFailed(l, _), .characteristicsDiscoveryFailed(r, _)): return l == r
     case let (.characteristicWriteFailed(l, _), .characteristicWriteFailed(r, _)): return l == r
     case let (.characteristicReadFailed(l, _), .characteristicReadFailed(r, _)): return l == r
     case let (.characteristicNotifyChangeFailed(l, _), .characteristicNotifyChangeFailed(r, _)): return l == r
-        // Descriptors
+    case let (.characteristicStateChangedFailed(l, _), .characteristicStateChangedFailed(r, _)): return l == r
+    // Descriptors
     case let (.descriptorsDiscoveryFailed(l, _), .descriptorsDiscoveryFailed(r, _)): return l == r
     case let (.descriptorWriteFailed(l, _), .descriptorWriteFailed(r, _)): return l == r
     case let (.descriptorReadFailed(l, _), .descriptorReadFailed(r, _)): return l == r

--- a/Tests/Autogenerated/_BluetoothError.generated.swift
+++ b/Tests/Autogenerated/_BluetoothError.generated.swift
@@ -91,7 +91,7 @@ extension _BluetoothError: CustomStringConvertible {
         case let .characteristicNotifyChangeFailed(_, err):
             return "_Characteristic notify change error has occured: \(err?.localizedDescription ?? "-")"
         case let .characteristicSetNotifyValueFailed(_, err):
-            return "_Characteristic state change error has occured: \(err?.localizedDescription ?? "-")"
+            return "_Characteristic isNotyfing value change error has occured: \(err?.localizedDescription ?? "-")"
         // Descriptors
         case let .descriptorsDiscoveryFailed(_, err):
             return "_Descriptor discovery error has occured: \(err?.localizedDescription ?? "-")"

--- a/Tests/Autogenerated/_BluetoothError.generated.swift
+++ b/Tests/Autogenerated/_BluetoothError.generated.swift
@@ -29,7 +29,7 @@ enum _BluetoothError: Error {
     case characteristicWriteFailed(_Characteristic, Error?)
     case characteristicReadFailed(_Characteristic, Error?)
     case characteristicNotifyChangeFailed(_Characteristic, Error?)
-    case characteristicStateChangedFailed(_Characteristic, Error?)
+    case characteristicSetNotifyValueFailed(_Characteristic, Error?)
     // Descriptors
     case descriptorsDiscoveryFailed(_Characteristic, Error?)
     case descriptorWriteFailed(_Descriptor, Error?)
@@ -90,7 +90,7 @@ extension _BluetoothError: CustomStringConvertible {
             return "_Characteristic read error has occured: \(err?.localizedDescription ?? "-")"
         case let .characteristicNotifyChangeFailed(_, err):
             return "_Characteristic notify change error has occured: \(err?.localizedDescription ?? "-")"
-        case let .characteristicStateChangedFailed(_, err):
+        case let .characteristicSetNotifyValueFailed(_, err):
             return "_Characteristic state change error has occured: \(err?.localizedDescription ?? "-")"
         // Descriptors
         case let .descriptorsDiscoveryFailed(_, err):
@@ -150,7 +150,7 @@ func == (lhs: _BluetoothError, rhs: _BluetoothError) -> Bool {
     case let (.characteristicWriteFailed(l, _), .characteristicWriteFailed(r, _)): return l == r
     case let (.characteristicReadFailed(l, _), .characteristicReadFailed(r, _)): return l == r
     case let (.characteristicNotifyChangeFailed(l, _), .characteristicNotifyChangeFailed(r, _)): return l == r
-    case let (.characteristicStateChangedFailed(l, _), .characteristicStateChangedFailed(r, _)): return l == r
+    case let (.characteristicSetNotifyValueFailed(l, _), .characteristicSetNotifyValueFailed(r, _)): return l == r
     // Descriptors
     case let (.descriptorsDiscoveryFailed(l, _), .descriptorsDiscoveryFailed(r, _)): return l == r
     case let (.descriptorWriteFailed(l, _), .descriptorWriteFailed(r, _)): return l == r

--- a/Tests/Autogenerated/_Characteristic.generated.swift
+++ b/Tests/Autogenerated/_Characteristic.generated.swift
@@ -61,6 +61,13 @@ class _Characteristic {
         return service.peripheral.observeWrite(for: self)
     }
 
+    /// Function that aloows to know the exact time, when isNotyfing value has changed on a characteristic.
+    ///
+    /// - returns: `Observable` emitting `_Characteristic` when isNoytfing value has changed.
+    func observeNotifyValue() -> Observable<_Characteristic> {
+        return service.peripheral.observeNotifyValue(for: self)
+    }
+
     /// Function that triggers write of data to characteristic. Write is called after subscribtion to `Observable` is made.
     /// Behavior of this function strongly depends on [CBCharacteristicWriteType](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBPeripheral_Class/#//apple_ref/swift/enum/c:@E@CBCharacteristicWriteType), so be sure to check this out before usage of the method.
     /// - parameter data: `Data` that'll be written to the `_Characteristic`

--- a/Tests/Autogenerated/_Peripheral.generated.swift
+++ b/Tests/Autogenerated/_Peripheral.generated.swift
@@ -348,6 +348,10 @@ class _Peripheral {
         return ensureValidPeripheralState(for: observable)
     }
 
+    /// Use this function in order to know the exact time, when isNotyfing value has changed on a _Characteristic.
+    ///
+    /// - parameter characteristic: `_Characteristic` which you observe for isNotyfing changes.
+    /// - returns: `Observable` emitting `_Characteristic` when given characteristic has changed it's isNoytfing value.
     func observeNotifyValue(for characteristic: _Characteristic) -> Observable<_Characteristic> {
         return delegateWrapper.peripheralDidUpdateNotificationStateForCharacteristic
             .filter { $0.0 == characteristic.characteristic }
@@ -355,7 +359,7 @@ class _Peripheral {
                 guard let strongSelf = self else { throw _BluetoothError.destroyed }
                 let characteristic = _Characteristic(characteristic: cbCharacteristic, peripheral: strongSelf)
                 if let error = error {
-                    throw _BluetoothError.characteristicStateChangedFailed(characteristic, error)
+                    throw _BluetoothError.characteristicSetNotifyValueFailed(characteristic, error)
                 }
                 return characteristic
         }

--- a/Tests/Autogenerated/_Peripheral.generated.swift
+++ b/Tests/Autogenerated/_Peripheral.generated.swift
@@ -348,7 +348,7 @@ class _Peripheral {
         return ensureValidPeripheralState(for: observable)
     }
 
-    func observeCharacteristicStateChanged(for characteristic: _Characteristic) -> Observable<_Characteristic> {
+    func observeNotifyValue(for characteristic: _Characteristic) -> Observable<_Characteristic> {
         return delegateWrapper.peripheralDidUpdateNotificationStateForCharacteristic
             .filter { $0.0 == characteristic.characteristic }
             .map { [weak self] (cbCharacteristic, error) -> _Characteristic in

--- a/Tests/Autogenerated/_Peripheral.generated.swift
+++ b/Tests/Autogenerated/_Peripheral.generated.swift
@@ -348,6 +348,19 @@ class _Peripheral {
         return ensureValidPeripheralState(for: observable)
     }
 
+    func observeCharacteristicStateChanged(for characteristic: _Characteristic) -> Observable<_Characteristic> {
+        return delegateWrapper.peripheralDidUpdateNotificationStateForCharacteristic
+            .filter { $0.0 == characteristic.characteristic }
+            .map { [weak self] (cbCharacteristic, error) -> _Characteristic in
+                guard let strongSelf = self else { throw _BluetoothError.destroyed }
+                let characteristic = _Characteristic(characteristic: cbCharacteristic, peripheral: strongSelf)
+                if let error = error {
+                    throw _BluetoothError.characteristicStateChangedFailed(characteristic, error)
+                }
+                return characteristic
+        }
+    }
+
     // MARK: Descriptors
 
     /// Function that triggers descriptors discovery for characteristic

--- a/Tests/PeripheralTest+CharacteristicOperation.swift
+++ b/Tests/PeripheralTest+CharacteristicOperation.swift
@@ -184,7 +184,7 @@ class PeripheralCharacteristicOperationsTest: BasePeripheralTest {
         let characteristic = _Characteristic(characteristic: mockCharacteristic, peripheral: peripheral)
 
         let obs: ScheduledObservable<_Characteristic> = testScheduler.scheduleObservable {
-            self.peripheral.observeCharacteristicStateChanged(for: characteristic)
+            self.peripheral.observeNotifyValue(for: characteristic)
         }
 
         let updateEvents: [Recorded<Event<(CBCharacteristicMock, Error?)>>] = [

--- a/Tests/PeripheralTest+CharacteristicOperation.swift
+++ b/Tests/PeripheralTest+CharacteristicOperation.swift
@@ -179,6 +179,27 @@ class PeripheralCharacteristicOperationsTest: BasePeripheralTest {
         XCTAssertEqual(obs.events[0].value.element, characteristic, "should receive event for correct characteristic")
     }
     
+     func testobserveCharacteristicStateChanged() {
+        let mockCharacteristic = createCharacteristic(uuid: "0x0001", service: service)
+        let characteristic = _Characteristic(characteristic: mockCharacteristic, peripheral: peripheral)
+
+        let obs: ScheduledObservable<_Characteristic> = testScheduler.scheduleObservable {
+            self.peripheral.observeCharacteristicStateChanged(for: characteristic)
+        }
+
+        let updateEvents: [Recorded<Event<(CBCharacteristicMock, Error?)>>] = [
+            next(subscribeTime + 100, (mockCharacteristic, nil)),
+            next(subscribeTime + 200, (mockCharacteristic, nil))
+        ]
+        
+        testScheduler.createHotObservable(updateEvents).subscribe(peripheral.delegateWrapper.peripheralDidUpdateNotificationStateForCharacteristic).disposed(by: disposeBag)
+
+        testScheduler.advanceTo(subscribeTime + 200)
+        
+        XCTAssertEqual(obs.events.count, 2, "Should receive two events")
+        XCTAssertEqual(obs.events[0].value.element, characteristic, "should receive event for correct characteristic")
+    }
+    
     func testReadValue() {
         let characteristic = _Characteristic(characteristic: createCharacteristic(uuid: "0x0001", service: service), peripheral: peripheral)
         

--- a/Tests/PeripheralTest+CharacteristicOperation.swift
+++ b/Tests/PeripheralTest+CharacteristicOperation.swift
@@ -179,7 +179,7 @@ class PeripheralCharacteristicOperationsTest: BasePeripheralTest {
         XCTAssertEqual(obs.events[0].value.element, characteristic, "should receive event for correct characteristic")
     }
     
-     func testobserveCharacteristicStateChanged() {
+     func testObserveCharacteristicIsNotifyingValue() {
         let mockCharacteristic = createCharacteristic(uuid: "0x0001", service: service)
         let characteristic = _Characteristic(characteristic: mockCharacteristic, peripheral: peripheral)
 
@@ -194,6 +194,27 @@ class PeripheralCharacteristicOperationsTest: BasePeripheralTest {
         
         testScheduler.createHotObservable(updateEvents).subscribe(peripheral.delegateWrapper.peripheralDidUpdateNotificationStateForCharacteristic).disposed(by: disposeBag)
 
+        testScheduler.advanceTo(subscribeTime + 200)
+        
+        XCTAssertEqual(obs.events.count, 2, "Should receive two events")
+        XCTAssertEqual(obs.events[0].value.element, characteristic, "should receive event for correct characteristic")
+    }
+    
+    func testCharacteristicIsNotifyingValueChange() {
+        let mockCharacteristic = createCharacteristic(uuid: "0x0001", service: service)
+        let characteristic = _Characteristic(characteristic: mockCharacteristic, peripheral: peripheral)
+        
+        let obs: ScheduledObservable<_Characteristic> = testScheduler.scheduleObservable {
+            characteristic.observeNotifyValue()
+        }
+        
+        let updateEvents: [Recorded<Event<(CBCharacteristicMock, Error?)>>] = [
+            next(subscribeTime + 100, (mockCharacteristic, nil)),
+            next(subscribeTime + 200, (mockCharacteristic, nil))
+        ]
+        
+        testScheduler.createHotObservable(updateEvents).subscribe(peripheral.delegateWrapper.peripheralDidUpdateNotificationStateForCharacteristic).disposed(by: disposeBag)
+        
         testScheduler.advanceTo(subscribeTime + 200)
         
         XCTAssertEqual(obs.events.count, 2, "Should receive two events")


### PR DESCRIPTION
Added public method observeCharacteristicStateChanged(:_)
to Peripheral class, which maps events coming from
delegateWrapper.peripheralDidUpdateNotificationStateForCharacteristic
to determine when given Characteristic has changed it's state
(e.g isNotyfing). CBPeripheralDelegateWrapper field is private
in the Characteristic class, hence the need for providing public
access to it's functionality through Peripheral.

Also .characteristicStateChangedFailed was added to BluetoothError.