### PR TITLE
Added availabilty check in writeValue(:_) method in Peripheral.swift

### DIFF
--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -282,17 +282,22 @@ public class Peripheral {
         }
         switch type {
         case .withoutResponse:
-            return Observable<Characteristic>.deferred { [weak self] in
-                guard let strongSelf = self else { throw BluetoothError.destroyed }
-                return strongSelf.observeWriteWithoutResponseReadiness()
-                    .map { _ in true }
-                    .startWith(strongSelf.canSendWriteWithoutResponse)
-                    .filter { $0 }
-                    .take(1)
-                    .flatMap { _ in
-                        writeOperationPerformingAndListeningObservable(Observable.just(characteristic))
-                    }
-            }.asSingle()
+            if #available(iOS 11.0, *) {
+                return Observable<Characteristic>.deferred { [weak self] in
+                    guard let strongSelf = self else { throw BluetoothError.destroyed }
+                    return strongSelf.observeWriteWithoutResponseReadiness()
+                        .map { _ in true }
+                        .startWith(strongSelf.canSendWriteWithoutResponse)
+                        .filter { $0 }
+                        .take(1)
+                        .flatMap { _ in
+                            writeOperationPerformingAndListeningObservable(Observable.just(characteristic))
+                        }
+                    }.asSingle()
+            } else {
+                return writeOperationPerformingAndListeningObservable(Observable.just(characteristic))
+                    .asSingle()
+            }
         case .withResponse:
             return writeOperationPerformingAndListeningObservable(observeWrite(for: characteristic).take(1))
                 .asSingle()


### PR DESCRIPTION
CBCharacteristicWriteType.withoutResponse was introduced in iOS 11.
Prior to this commit, there was no availability check performed,
which was causing a crash on devices with system version lower
than iOS 11. Now if the device's system is lower, we use
.withResponse case.