### PR TITLE
Added "requests queues" to the discovery operations.

### DIFF
--- a/RxBluetoothKit.xcodeproj/project.pbxproj
+++ b/RxBluetoothKit.xcodeproj/project.pbxproj
@@ -311,7 +311,7 @@
 		1DCA1EEE2028628D0090D14E /* _CharacteristicNotificationManager.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _CharacteristicNotificationManager.generated.swift; sourceTree = "<group>"; };
 		1DCA1EF42028680D0090D14E /* CharacteristicNotificationManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacteristicNotificationManagerTest.swift; sourceTree = "<group>"; };
 		26509A761CC1270100EBA319 /* DeviceIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceIdentifiers.swift; sourceTree = "<group>"; };
-		26509A781CC1275E00EBA319 /* Peripheral+Convenience.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Peripheral+Convenience.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		26509A781CC1275E00EBA319 /* Peripheral+Convenience.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Peripheral+Convenience.swift"; sourceTree = "<group>"; };
 		2666FCED1CCE42A5005E81CE /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Source/Info.plist; sourceTree = "<group>"; };
 		2666FCEE1CCE42A5005E81CE /* RxBluetoothKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RxBluetoothKit.h; path = Source/RxBluetoothKit.h; sourceTree = "<group>"; };
 		2666FD061CCE430F005E81CE /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };

--- a/Source/Boxes.swift
+++ b/Source/Boxes.swift
@@ -38,6 +38,12 @@ class ThreadSafeBox<T>: CustomDebugStringConvertible {
         }
     }
 
+    func writeSync(_ block: @escaping (inout T) -> Void) {
+        queue.sync {
+            block(&self.value)
+        }
+    }
+
     @discardableResult func compareAndSet(compare: (T) -> Bool, set: @escaping (inout T) -> Void) -> Bool {
         var result: Bool = false
         queue.sync {

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -3,6 +3,7 @@ import RxSwift
 import CoreBluetooth
 
 // swiftlint:disable line_length
+// swiftlint:disable type_body_length
 
 /// Peripheral is a class implementing ReactiveX API which wraps all Core Bluetooth functions
 /// allowing to talk to peripheral like discovering characteristics, services and all of the read/write calls.
@@ -18,6 +19,17 @@ public class Peripheral {
     private let notificationManager: CharacteristicNotificationManager
 
     let delegateWrapper: CBPeripheralDelegateWrapper
+
+    private let remainingServicesDiscoveryRequest = ThreadSafeBox<Int>(value: 0)
+    private let peripheralDidDiscoverServices = PublishSubject<([CBService]?, Error?)>()
+
+    private let remainingIncludedServicesDiscoveryRequest = ThreadSafeBox<[CBUUID: Int]>(value: [CBUUID: Int]())
+    private let peripheralDidDiscoverIncludedServicesForService = PublishSubject<(CBService, Error?)>()
+
+    private let remainingCharacteristicsDiscoveryRequest = ThreadSafeBox<[CBUUID: Int]>(value: [CBUUID: Int]())
+    private let peripheralDidDiscoverCharacteristicsForService = PublishSubject<(CBService, Error?)>()
+
+    private let disposeBag = DisposeBag()
 
     /// Creates new `Peripheral`
     /// - parameter manager: Central instance which is used to perform all of the necessary operations.
@@ -35,11 +47,51 @@ public class Peripheral {
         self.delegateWrapper = delegateWrapper
         self.notificationManager = notificationManager
         peripheral.delegate = self.delegateWrapper
+
+        setupSubjects()
     }
 
-    convenience init(manager: CentralManager, peripheral: CBPeripheral, delegateWrapper: CBPeripheralDelegateWrapper) {
+    convenience init(manager: CentralManager,
+                     peripheral: CBPeripheral,
+                     delegateWrapper: CBPeripheralDelegateWrapper) {
         let notificationManager = CharacteristicNotificationManager(peripheral: peripheral, delegateWrapper: delegateWrapper)
-        self.init(manager: manager, peripheral: peripheral, delegateWrapper: delegateWrapper, notificationManager: notificationManager)
+        self.init(manager: manager,
+                  peripheral: peripheral,
+                  delegateWrapper: delegateWrapper,
+                  notificationManager: notificationManager)
+    }
+
+    private func setupSubjects() {
+        delegateWrapper.peripheralDidDiscoverServices.subscribe { [weak self] event in
+            self?.remainingServicesDiscoveryRequest.write { [weak self] value in
+                if value > 0 {
+                    value -= 1
+                }
+                self?.peripheralDidDiscoverServices.on(event)
+            }
+        }.disposed(by: disposeBag)
+
+        delegateWrapper.peripheralDidDiscoverIncludedServicesForService.subscribe { [weak self] event in
+            self?.remainingIncludedServicesDiscoveryRequest.write { [weak self] array in
+                if let element = event.element {
+                    let oldValue = array[element.0.uuid] ?? 1
+                    array[element.0.uuid] = oldValue - 1
+                }
+
+                self?.peripheralDidDiscoverIncludedServicesForService.on(event)
+            }
+        }.disposed(by: disposeBag)
+
+        delegateWrapper.peripheralDidDiscoverCharacteristicsForService.subscribe { [weak self] event in
+            self?.remainingCharacteristicsDiscoveryRequest.write { [weak self] array in
+                if let element = event.element {
+                    let oldValue = array[element.0.uuid] ?? 1
+                    array[element.0.uuid] = oldValue - 1
+                }
+
+                self?.peripheralDidDiscoverCharacteristicsForService.on(event)
+            }
+        }.disposed(by: disposeBag)
     }
 
     /// Attaches RxBluetoothKit delegate to CBPeripheral.
@@ -108,8 +160,6 @@ public class Peripheral {
     /// Triggers discover of specified services of peripheral. If the servicesUUIDs parameter is nil, all the available services of the
     /// peripheral are returned; setting the parameter to nil is considerably slower and is not recommended.
     /// If all of the specified services are already discovered - these are returned without doing any underlying Bluetooth operations.
-    /// Next on returned `Observable` is emitted only when all of the requested services are discovered, otherwise`RxError.noElements`
-    /// error is emmited.
     ///
     /// - Parameter serviceUUIDs: An array of [CBUUID](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBUUID_Class/)
     /// objects that you are interested in. Here, each [CBUUID](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBUUID_Class/)
@@ -118,25 +168,36 @@ public class Peripheral {
     public func discoverServices(_ serviceUUIDs: [CBUUID]?) -> Single<[Service]> {
         if let identifiers = serviceUUIDs, !identifiers.isEmpty,
             let cachedServices = self.services,
-            let filteredServices = filterUUIDItems(uuids: serviceUUIDs, items: cachedServices) {
+            let filteredServices = filterUUIDItems(uuids: serviceUUIDs, items: cachedServices, requireAll: true) {
             return ensureValidPeripheralState(for: .just(filteredServices)).asSingle()
         }
         let observable = delegateWrapper.peripheralDidDiscoverServices
+            .filter { [weak self] (services, error) in
+                guard let strongSelf = self else { throw BluetoothError.destroyed }
+                guard let cachedServices = strongSelf.services, error == nil else { return true }
+                let foundRequestedServices = serviceUUIDs != nil && filterUUIDItems(uuids: serviceUUIDs, items: cachedServices, requireAll: true) != nil
+                return foundRequestedServices || strongSelf.remainingServicesDiscoveryRequest.read { $0 == 0 }
+            }
             .flatMap { [weak self] (_, error) -> Observable<[Service]> in
                 guard let strongSelf = self else { throw BluetoothError.destroyed }
                 guard let cachedServices = strongSelf.services, error == nil else {
                     throw BluetoothError.servicesDiscoveryFailed(strongSelf, error)
                 }
-                if let filteredServices = filterUUIDItems(uuids: serviceUUIDs, items: cachedServices) {
+                if let filteredServices = filterUUIDItems(uuids: serviceUUIDs, items: cachedServices, requireAll: false) {
                     return .just(filteredServices)
                 }
-                throw RxError.noElements
+                return .empty()
             }
             .take(1)
 
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
-            postSubscriptionCall: { [weak self] in self?.peripheral.discoverServices(serviceUUIDs) }
+            postSubscriptionCall: { [weak self] in
+                self?.remainingServicesDiscoveryRequest.write { [weak self] value in
+                    value += 1
+                    self?.peripheral.discoverServices(serviceUUIDs)
+                }
+            }
         )
         .asSingle()
     }
@@ -145,8 +206,6 @@ public class Peripheral {
     /// subscribtion to `Observable` is made.
     /// If all of the specified included services are already discovered - these are returned without doing any underlying Bluetooth
     /// operations.
-    /// Next on returned `Observable` is emitted only when all of the requested included services are discovered, otherwise`RxError.noElements`
-    /// error is emmited.
     ///
     /// - Parameter includedServiceUUIDs: Identifiers of included services that should be discovered. If `nil` - all of the
     /// included services will be discovered. If you'll pass empty array - none of them will be discovered.
@@ -155,29 +214,43 @@ public class Peripheral {
     public func discoverIncludedServices(_ includedServiceUUIDs: [CBUUID]?, for service: Service) -> Single<[Service]> {
         if let identifiers = includedServiceUUIDs, !identifiers.isEmpty,
             let services = service.includedServices,
-            let filteredServices = filterUUIDItems(uuids: includedServiceUUIDs, items: services) {
+            let filteredServices = filterUUIDItems(uuids: includedServiceUUIDs, items: services, requireAll: true) {
             return ensureValidPeripheralState(for: .just(filteredServices)).asSingle()
         }
         let observable = delegateWrapper
             .peripheralDidDiscoverIncludedServicesForService
             .filter { $0.0 == service.service }
-            .flatMap { [weak self] (service, error) -> Observable<[Service]> in
+            .filter { [weak self] (cbService, error) in
                 guard let strongSelf = self else { throw BluetoothError.destroyed }
-                guard let includedRxServices = service.includedServices, error == nil else {
+                guard let includedCBServices = cbService.includedServices, error == nil else { return true }
+
+                let includedServices = includedCBServices.map { Service(peripheral: strongSelf, service: $0) }
+                let foundRequestedServices = includedServiceUUIDs != nil && filterUUIDItems(uuids: includedServiceUUIDs, items: includedServices, requireAll: true) != nil
+                return foundRequestedServices || strongSelf.remainingIncludedServicesDiscoveryRequest.read { array in
+                    return (array[cbService.uuid] ?? 0) == 0
+                }
+            }
+            .flatMap { [weak self] (cbService, error) -> Observable<[Service]> in
+                guard let strongSelf = self else { throw BluetoothError.destroyed }
+                guard let includedRxServices = cbService.includedServices, error == nil else {
                     throw BluetoothError.includedServicesDiscoveryFailed(strongSelf, error)
                 }
                 let includedServices = includedRxServices.map { Service(peripheral: strongSelf, service: $0) }
-                if let filteredServices = filterUUIDItems(uuids: includedServiceUUIDs, items: includedServices) {
+                if let filteredServices = filterUUIDItems(uuids: includedServiceUUIDs, items: includedServices, requireAll: false) {
                     return .just(filteredServices)
                 }
-                throw RxError.noElements
+                return .empty()
             }
             .take(1)
 
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in
-                self?.peripheral.discoverIncludedServices(includedServiceUUIDs, for: service.service)
+                self?.remainingIncludedServicesDiscoveryRequest.write { [weak self] array in
+                    let oldValue = array[service.uuid] ?? 0
+                    array[service.uuid] = oldValue + 1
+                    self?.peripheral.discoverIncludedServices(includedServiceUUIDs, for: service.service)
+                }
             }
         )
         .asSingle()
@@ -188,8 +261,6 @@ public class Peripheral {
     /// Function that triggers characteristics discovery for specified Services and identifiers. Discovery is called after
     /// subscribtion to `Observable` is made.
     /// If all of the specified characteristics are already discovered - these are returned without doing any underlying Bluetooth operations.
-    /// Next on returned `Observable` is emitted only when all of the requested characteristics are discovered, otherwise`RxError.noElements`
-    /// error is emmited.
     ///
     /// - Parameter characteristicUUIDs: Identifiers of characteristics that should be discovered. If `nil` - all of the
     /// characteristics will be discovered. If you'll pass empty array - none of them will be discovered.
@@ -198,28 +269,43 @@ public class Peripheral {
     public func discoverCharacteristics(_ characteristicUUIDs: [CBUUID]?, for service: Service) -> Single<[Characteristic]> {
         if let identifiers = characteristicUUIDs, !identifiers.isEmpty,
             let characteristics = service.characteristics,
-            let filteredCharacteristics = filterUUIDItems(uuids: characteristicUUIDs, items: characteristics) {
+            let filteredCharacteristics = filterUUIDItems(uuids: characteristicUUIDs, items: characteristics, requireAll: true) {
             return ensureValidPeripheralState(for: .just(filteredCharacteristics)).asSingle()
         }
         let observable = delegateWrapper
             .peripheralDidDiscoverCharacteristicsForService
             .filter { $0.0 == service.service }
+            .filter { [weak self] (cbService, error) in
+                guard let strongSelf = self else { throw BluetoothError.destroyed }
+                guard let cbCharacteristics = cbService.characteristics, error == nil else { return true }
+
+                let characteristics = cbCharacteristics.map { Characteristic(characteristic: $0, service: service) }
+                let foundRequestedCharacteristis = characteristicUUIDs != nil && filterUUIDItems(uuids: characteristicUUIDs, items: characteristics, requireAll: true) != nil
+                return foundRequestedCharacteristis || strongSelf.remainingCharacteristicsDiscoveryRequest.read { array in
+                    return (array[cbService.uuid] ?? 0) == 0
+                }
+            }
             .flatMap { (cbService, error) -> Observable<[Characteristic]> in
                 guard let cbCharacteristics = cbService.characteristics, error == nil else {
                     throw BluetoothError.characteristicsDiscoveryFailed(service, error)
                 }
                 let characteristics = cbCharacteristics.map { Characteristic(characteristic: $0, service: service) }
-                if let filteredCharacteristics = filterUUIDItems(uuids: characteristicUUIDs, items: characteristics) {
+                if let filteredCharacteristics = filterUUIDItems(uuids: characteristicUUIDs, items: characteristics, requireAll: false) {
                     return .just(filteredCharacteristics)
                 }
-                throw RxError.noElements
+                return .empty()
             }
             .take(1)
 
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in
-                self?.peripheral.discoverCharacteristics(characteristicUUIDs, for: service.service)
+                self?.remainingCharacteristicsDiscoveryRequest.write { [weak self] array in
+                    let oldValue = array[service.uuid] ?? 0
+                    array[service.uuid] = oldValue + 1
+
+                    self?.peripheral.discoverCharacteristics(characteristicUUIDs, for: service.service)
+                }
             }
         ).asSingle()
     }

--- a/Source/UUIDIdentifiable.swift
+++ b/Source/UUIDIdentifiable.swift
@@ -7,15 +7,17 @@ protocol UUIDIdentifiable {
 
 /// Filters an item list based on the provided UUID list. The items must conform to UUIDIdentifiable.
 /// Only items returned whose UUID matches an item in the provided UUID list.
-/// Each UUID should have at least one item matching in the items list. Otherwise the result is nil.
+/// If requredAll is true, each UUID should have at least one item matching in the items list.
+/// Otherwise the result is nil.
 /// - uuids: a UUID list or nil
 /// - items: items to be filtered
+/// - requireAll: method will return nil if this param is true and uuids is not subset of items
 /// - Returns: the filtered item list
-func filterUUIDItems<T: UUIDIdentifiable>(uuids: [CBUUID]?, items: [T]) -> [T]? {
+func filterUUIDItems<T: UUIDIdentifiable>(uuids: [CBUUID]?, items: [T], requireAll: Bool) -> [T]? {
     guard let uuids = uuids, !uuids.isEmpty else { return items }
 
     let itemsUUIDs = items.map { $0.uuid }
     let uuidsSet = Set(uuids)
-    guard uuidsSet.isSubset(of: Set(itemsUUIDs)) else { return nil }
+    guard !requireAll || uuidsSet.isSubset(of: Set(itemsUUIDs)) else { return nil }
     return items.filter { uuidsSet.contains($0.uuid) }
 }

--- a/Tests/Autogenerated/_Peripheral.generated.swift
+++ b/Tests/Autogenerated/_Peripheral.generated.swift
@@ -64,34 +64,36 @@ class _Peripheral {
 
     private func setupSubjects() {
         delegateWrapper.peripheralDidDiscoverServices.subscribe { [weak self] event in
-            self?.remainingServicesDiscoveryRequest.write { [weak self] value in
+            self?.remainingServicesDiscoveryRequest.writeSync { value in
                 if value > 0 {
                     value -= 1
                 }
-                self?.peripheralDidDiscoverServices.on(event)
             }
+            self?.peripheralDidDiscoverServices.on(event)
         }.disposed(by: disposeBag)
 
         delegateWrapper.peripheralDidDiscoverIncludedServicesForService.subscribe { [weak self] event in
-            self?.remainingIncludedServicesDiscoveryRequest.write { [weak self] array in
+            self?.remainingIncludedServicesDiscoveryRequest.writeSync { array in
                 if let element = event.element {
                     let oldValue = array[element.0.uuid] ?? 1
-                    array[element.0.uuid] = oldValue - 1
+                    if oldValue > 0 {
+                        array[element.0.uuid] = oldValue - 1
+                    }
                 }
-
-                self?.peripheralDidDiscoverIncludedServicesForService.on(event)
             }
+            self?.peripheralDidDiscoverIncludedServicesForService.on(event)
         }.disposed(by: disposeBag)
 
         delegateWrapper.peripheralDidDiscoverCharacteristicsForService.subscribe { [weak self] event in
-            self?.remainingCharacteristicsDiscoveryRequest.write { [weak self] array in
+            self?.remainingCharacteristicsDiscoveryRequest.writeSync { array in
                 if let element = event.element {
                     let oldValue = array[element.0.uuid] ?? 1
-                    array[element.0.uuid] = oldValue - 1
+                    if oldValue > 0 {
+                        array[element.0.uuid] = oldValue - 1
+                    }
                 }
-
-                self?.peripheralDidDiscoverCharacteristicsForService.on(event)
             }
+            self?.peripheralDidDiscoverCharacteristicsForService.on(event)
         }.disposed(by: disposeBag)
     }
 
@@ -172,7 +174,7 @@ class _Peripheral {
             let filteredServices = filterUUIDItems(uuids: serviceUUIDs, items: cachedServices, requireAll: true) {
             return ensureValidPeripheralState(for: .just(filteredServices)).asSingle()
         }
-        let observable = delegateWrapper.peripheralDidDiscoverServices
+        let observable = peripheralDidDiscoverServices
             .filter { [weak self] (services, error) in
                 guard let strongSelf = self else { throw _BluetoothError.destroyed }
                 guard let cachedServices = strongSelf.services, error == nil else { return true }
@@ -194,10 +196,10 @@ class _Peripheral {
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in
-                self?.remainingServicesDiscoveryRequest.write { [weak self] value in
+                self?.remainingServicesDiscoveryRequest.writeSync { value in
                     value += 1
-                    self?.peripheral.discoverServices(serviceUUIDs)
                 }
+                self?.peripheral.discoverServices(serviceUUIDs)
             }
         )
         .asSingle()
@@ -218,8 +220,7 @@ class _Peripheral {
             let filteredServices = filterUUIDItems(uuids: includedServiceUUIDs, items: services, requireAll: true) {
             return ensureValidPeripheralState(for: .just(filteredServices)).asSingle()
         }
-        let observable = delegateWrapper
-            .peripheralDidDiscoverIncludedServicesForService
+        let observable = peripheralDidDiscoverIncludedServicesForService
             .filter { $0.0 == service.service }
             .filter { [weak self] (cbService, error) in
                 guard let strongSelf = self else { throw _BluetoothError.destroyed }
@@ -247,11 +248,11 @@ class _Peripheral {
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in
-                self?.remainingIncludedServicesDiscoveryRequest.write { [weak self] array in
+                self?.remainingIncludedServicesDiscoveryRequest.writeSync { array in
                     let oldValue = array[service.uuid] ?? 0
                     array[service.uuid] = oldValue + 1
-                    self?.peripheral.discoverIncludedServices(includedServiceUUIDs, for: service.service)
                 }
+                self?.peripheral.discoverIncludedServices(includedServiceUUIDs, for: service.service)
             }
         )
         .asSingle()
@@ -273,8 +274,7 @@ class _Peripheral {
             let filteredCharacteristics = filterUUIDItems(uuids: characteristicUUIDs, items: characteristics, requireAll: true) {
             return ensureValidPeripheralState(for: .just(filteredCharacteristics)).asSingle()
         }
-        let observable = delegateWrapper
-            .peripheralDidDiscoverCharacteristicsForService
+        let observable = peripheralDidDiscoverCharacteristicsForService
             .filter { $0.0 == service.service }
             .filter { [weak self] (cbService, error) in
                 guard let strongSelf = self else { throw _BluetoothError.destroyed }
@@ -301,12 +301,11 @@ class _Peripheral {
         return ensureValidPeripheralStateAndCallIfSucceeded(
             for: observable,
             postSubscriptionCall: { [weak self] in
-                self?.remainingCharacteristicsDiscoveryRequest.write { [weak self] array in
+                self?.remainingCharacteristicsDiscoveryRequest.writeSync { array in
                     let oldValue = array[service.uuid] ?? 0
                     array[service.uuid] = oldValue + 1
-
-                    self?.peripheral.discoverCharacteristics(characteristicUUIDs, for: service.service)
                 }
+                self?.peripheral.discoverCharacteristics(characteristicUUIDs, for: service.service)
             }
         ).asSingle()
     }

--- a/Tests/PeripheralTest+CharacteristicsDiscover.swift
+++ b/Tests/PeripheralTest+CharacteristicsDiscover.swift
@@ -99,6 +99,51 @@ class PeripheralCharacteristicsDiscoverTest: BasePeripheralTest {
         XCTAssertEqual(peripheral.peripheral.discoverCharacteristicsParams.count, 1, "should call discover characteristics for the peripheral")
         XCTAssertCharacteristicsList(observable: obs, uuids: mockCharacteristics.map { $0.uuid })
     }
+    
+    func testDiscoveryQueue() {
+        let mockCharacteristics = [
+            createCharacteristic(uuid: "0x0000"),
+            createCharacteristic(uuid: "0x0001")
+        ]
+        
+        let obs0: ScheduledObservable<[_Characteristic]> = testScheduler.scheduleObservable {
+            self.peripheral.discoverCharacteristics(nil, for: self.service).asObservable()
+        }
+        let obs1: ScheduledObservable<[_Characteristic]> = testScheduler.scheduleObservable {
+            self.peripheral.discoverCharacteristics([mockCharacteristics[0].uuid], for: self.service).asObservable()
+        }
+        let obs2: ScheduledObservable<[_Characteristic]> = testScheduler.scheduleObservable {
+            self.peripheral.discoverCharacteristics([mockCharacteristics[1].uuid], for: self.service).asObservable()
+        }
+        testScheduler.scheduleAt(subscribeTime + 100) {
+            self.service.service.characteristics = [mockCharacteristics[0]]
+            self.peripheral.delegateWrapper.peripheralDidDiscoverCharacteristicsForService.asObserver().onNext((self.service.service, nil))
+        }
+        testScheduler.scheduleAt(subscribeTime + 200) {
+            self.service.service.characteristics = mockCharacteristics
+            self.peripheral.delegateWrapper.peripheralDidDiscoverCharacteristicsForService.asObserver().onNext((self.service.service, nil))
+        }
+        testScheduler.scheduleAt(subscribeTime + 300) {
+            self.service.service.characteristics = mockCharacteristics
+            self.peripheral.delegateWrapper.peripheralDidDiscoverCharacteristicsForService.asObserver().onNext((self.service.service, nil))
+        }
+        
+        testScheduler.advanceTo(subscribeTime + 100)
+        
+        XCTAssertEqual(peripheral.peripheral.discoverCharacteristicsParams.count, 3, "should call discover included services 3 times")
+        XCTAssertEqual(obs0.events.count, 0, "should not receive event for first request")
+        XCTAssertCharacteristicsList(observable: obs1, uuids: [mockCharacteristics[0].uuid])
+        XCTAssertEqual(obs2.events.count, 0, "should not receive event for third request")
+        
+        testScheduler.advanceTo(subscribeTime + 200)
+        
+        XCTAssertCharacteristicsList(observable: obs2, uuids: [mockCharacteristics[1].uuid] )
+        XCTAssertEqual(obs0.events.count, 0, "should not receive event for first request")
+        
+        testScheduler.advanceTo(subscribeTime + 300)
+        
+        XCTAssertCharacteristicsList(observable: obs0, uuids: mockCharacteristics.map { $0.uuid } )
+    }
 
     func testDiscoverCharacteristicsForDisconnectedPeripheral() {
         peripheral.peripheral.state = .disconnected

--- a/Tests/UUIDIdentifiableTest.swift
+++ b/Tests/UUIDIdentifiableTest.swift
@@ -17,7 +17,7 @@ class UUIDIdentifiableTest: XCTestCase {
             TestElement(uuid: CBUUID(string: "0x0002")),
             TestElement(uuid: CBUUID(string: "0x0003"))
         ]
-        let result = filterUUIDItems(uuids: filterList, items: sourceElements)
+        let result = filterUUIDItems(uuids: filterList, items: sourceElements, requireAll: true)
         
         XCTAssertNotNil(result, "should return a result")
         XCTAssertEqual(result!, [sourceElements[1], sourceElements[3]], "should filter elements")
@@ -29,7 +29,7 @@ class UUIDIdentifiableTest: XCTestCase {
             CBUUID(string: "0x0003"),
         ]
         
-        let result = filterUUIDItems(uuids: filterList, items: [TestElement]())
+        let result = filterUUIDItems(uuids: filterList, items: [TestElement](), requireAll: true)
         
         XCTAssertNil(result, "should return nil")
     }
@@ -44,7 +44,7 @@ class UUIDIdentifiableTest: XCTestCase {
             TestElement(uuid: CBUUID(string: "0x0000")),
             TestElement(uuid: CBUUID(string: "0x0001"))
         ]
-        let result = filterUUIDItems(uuids: filterList, items: sourceElements)
+        let result = filterUUIDItems(uuids: filterList, items: sourceElements, requireAll: true)
         
         XCTAssertNil(result, "should return nil")
     }
@@ -58,7 +58,7 @@ class UUIDIdentifiableTest: XCTestCase {
         let sourceElements = [
             TestElement(uuid: CBUUID(string: "0x0000"))
         ]
-        let result = filterUUIDItems(uuids: filterList, items: sourceElements)
+        let result = filterUUIDItems(uuids: filterList, items: sourceElements, requireAll: true)
         
         XCTAssertNil(result, "should return nil")
     }
@@ -68,7 +68,7 @@ class UUIDIdentifiableTest: XCTestCase {
             TestElement(uuid: CBUUID(string: "0x0000")),
             TestElement(uuid: CBUUID(string: "0x0001"))
         ]
-        let result = filterUUIDItems(uuids: [CBUUID](), items: sourceElements)
+        let result = filterUUIDItems(uuids: [CBUUID](), items: sourceElements, requireAll: true)
         
         XCTAssertNotNil(result, "should return a result")
         XCTAssertEqual(result!, sourceElements, "should return all elements")
@@ -79,10 +79,37 @@ class UUIDIdentifiableTest: XCTestCase {
             TestElement(uuid: CBUUID(string: "0x0000")),
             TestElement(uuid: CBUUID(string: "0x0001"))
         ]
-        let result = filterUUIDItems(uuids: nil, items: sourceElements)
+        let result = filterUUIDItems(uuids: nil, items: sourceElements, requireAll: true)
         
         XCTAssertNotNil(result, "should return a result")
         XCTAssertEqual(result!, sourceElements, "should return all elements")
+    }
+    
+    func testItemsFilterNotAllItemsRequired() {
+        let filterList = [
+            CBUUID(string: "0x0001"),
+            CBUUID(string: "0x0002")
+        ]
+        
+        let sourceElements = [
+            TestElement(uuid: CBUUID(string: "0x0000")),
+            TestElement(uuid: CBUUID(string: "0x0001"))
+        ]
+        let result = filterUUIDItems(uuids: filterList, items: sourceElements, requireAll: false)
+        
+        XCTAssertNotNil(result, "should return a result")
+        XCTAssertEqual(result!, [sourceElements[1]], "should return found elements")
+    }
+    
+    func testItemsFilterNotAllItemsRequiredNoElementsFount() {
+        let filterList = [
+            CBUUID(string: "0x0000"),
+            CBUUID(string: "0x0001")
+        ]
+        let result = filterUUIDItems(uuids: filterList, items: [TestElement](), requireAll: false)
+        
+        XCTAssertNotNil(result, "should return a result")
+        XCTAssertEqual(result!, [], "should return empty array")
     }
 }
 


### PR DESCRIPTION
This commit resolves problems with discovery operations when app wants to discover services, includedServices or characteristics. For example when app calls `discoverServices` two times in a row with different uuids and second call happen before getting response for the first call there was a problem in current version. In this situation observer that subscribe on the second request will get an error instead waiting for response for its requests.

This pull request introduce a new logic to the discovery operations. Now observables will not return any result until all requested components are discovered or all requests returns a result.

It resolves also #235 