### PR TITLE
Changed peripheral already connected error

### DIFF
--- a/RxBluetoothKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/RxBluetoothKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/BluetoothError.swift
+++ b/Source/BluetoothError.swift
@@ -16,7 +16,7 @@ public enum BluetoothError: Error {
     case bluetoothInUnknownState
     case bluetoothResetting
     // Peripheral
-    case peripheralIsConnectingOrAlreadyConnected(Peripheral)
+    case peripheralIsAlreadyObservingConnection(Peripheral)
     case peripheralConnectionFailed(Peripheral, Error?)
     case peripheralDisconnected(Peripheral, Error?)
     case peripheralRSSIReadFailed(Peripheral, Error?)
@@ -63,11 +63,11 @@ extension BluetoothError: CustomStringConvertible {
         case .bluetoothResetting:
             return "Bluetooth is resetting"
         // Peripheral
-        case .peripheralIsConnectingOrAlreadyConnected:
+        case .peripheralIsAlreadyObservingConnection:
             return """
-            Peripheral is already connected or is in connecting state.
-            You cannot connect to peripheral when you have previously connected to it
-            or there is ongoing connection try.
+            Peripheral connection is already being observed.
+            You cannot try to establishConnection to peripheral when you have ongoing
+            connection (previously establishConnection subscription was not disposed).
             """
         case let .peripheralConnectionFailed(_, err):
             return "Connection error has occured: \(err?.localizedDescription ?? "-")"
@@ -140,7 +140,7 @@ public func == (lhs: BluetoothError, rhs: BluetoothError) -> Bool {
     case let (.servicesDiscoveryFailed(l, _), .servicesDiscoveryFailed(r, _)): return l == r
     case let (.includedServicesDiscoveryFailed(l, _), .includedServicesDiscoveryFailed(r, _)): return l == r
     // Peripherals
-    case let (.peripheralIsConnectingOrAlreadyConnected(l), .peripheralIsConnectingOrAlreadyConnected(r)): return l == r
+    case let (.peripheralIsAlreadyObservingConnection(l), .peripheralIsAlreadyObservingConnection(r)): return l == r
     case let (.peripheralConnectionFailed(l, _), .peripheralConnectionFailed(r, _)): return l == r
     case let (.peripheralDisconnected(l, _), .peripheralDisconnected(r, _)): return l == r
     case let (.peripheralRSSIReadFailed(l, _), .peripheralRSSIReadFailed(r, _)): return l == r

--- a/Source/Connector.swift
+++ b/Source/Connector.swift
@@ -70,7 +70,7 @@ class Connector {
             )
 
             guard connectingStarted else {
-                observer.onError(BluetoothError.peripheralIsConnectingOrAlreadyConnected(peripheral))
+                observer.onError(BluetoothError.peripheralIsAlreadyObservingConnection(peripheral))
                 return Disposables.create()
             }
 

--- a/Templates/Mock.swifttemplate
+++ b/Templates/Mock.swifttemplate
@@ -83,7 +83,7 @@ import RxSwift
         }
 
         static func printMethodParamTypes(_ method: SourceryRuntime.Method) -> String {
-            return method.parameters.reduce("", { "\($0)\(changeTypeName($1.typeName.name)), " }).dropLast(2)
+            return String(method.parameters.reduce("", { "\($0)\(changeTypeName($1.typeName.name)), " }).dropLast(2))
         }
 
         static func printMethodName(_ method: SourceryRuntime.Method, changeTypeNames: Bool = true) -> String {

--- a/Tests/Autogenerated/Mock.generated.swift
+++ b/Tests/Autogenerated/Mock.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.10.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.12.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import CoreBluetooth
@@ -260,8 +260,8 @@ class PeripheralProviderMock: NSObject {
 class ConnectorMock: NSObject {
     var centralManager: CBCentralManagerMock!
     var delegateWrapper: CBCentralManagerDelegateWrapperMock!
-    var connectingBox: ThreadSafeBox<[UUID]>!
-    var disconnectingBox: ThreadSafeBox<[UUID]>!
+    var connectedBox: ThreadSafeBox<Set<UUID>>!
+    var disconnectingBox: ThreadSafeBox<Set<UUID>>!
 
     override init() {
     }
@@ -333,6 +333,7 @@ class CharacteristicNotificationManagerMock: NSObject {
     var peripheral: CBPeripheralMock!
     var delegateWrapper: CBPeripheralDelegateWrapperMock!
     var uuidToActiveObservableMap: [CBUUID: Observable<_Characteristic>]!
+    var uuidToActiveObservablesCountMap: [CBUUID: Int]!
     var lock: NSLock!
 
     override init() {
@@ -365,15 +366,8 @@ class CharacteristicNotificationManagerMock: NSObject {
     }
 
     var setNotifyValueParams: [(Bool, _Characteristic)] = []
-    var setNotifyValueReturns: [Single<_Characteristic>] = []
-    var setNotifyValueReturn: Single<_Characteristic>?
-    func setNotifyValue(_ enabled: Bool, for characteristic: _Characteristic) -> Single<_Characteristic> {
+    func setNotifyValue(_ enabled: Bool, for characteristic: _Characteristic) {
         setNotifyValueParams.append((enabled, characteristic))
-        if setNotifyValueReturns.isEmpty {
-            return setNotifyValueReturn!
-        } else {
-            return setNotifyValueReturns.removeFirst()
-        }
     }
 
 }

--- a/Tests/Autogenerated/_BluetoothError.generated.swift
+++ b/Tests/Autogenerated/_BluetoothError.generated.swift
@@ -17,7 +17,7 @@ enum _BluetoothError: Error {
     case bluetoothInUnknownState
     case bluetoothResetting
     // _Peripheral
-    case peripheralIsConnectingOrAlreadyConnected(_Peripheral)
+    case peripheralIsAlreadyObservingConnection(_Peripheral)
     case peripheralConnectionFailed(_Peripheral, Error?)
     case peripheralDisconnected(_Peripheral, Error?)
     case peripheralRSSIReadFailed(_Peripheral, Error?)
@@ -64,11 +64,11 @@ extension _BluetoothError: CustomStringConvertible {
         case .bluetoothResetting:
             return "Bluetooth is resetting"
         // _Peripheral
-        case .peripheralIsConnectingOrAlreadyConnected:
+        case .peripheralIsAlreadyObservingConnection:
             return """
-            _Peripheral is already connected or is in connecting state.
-            You cannot connect to peripheral when you have previously connected to it
-            or there is ongoing connection try.
+            _Peripheral connection is already being observed.
+            You cannot try to establishConnection to peripheral when you have ongoing
+            connection (previously establishConnection subscription was not disposed).
             """
         case let .peripheralConnectionFailed(_, err):
             return "Connection error has occured: \(err?.localizedDescription ?? "-")"
@@ -141,7 +141,7 @@ func == (lhs: _BluetoothError, rhs: _BluetoothError) -> Bool {
     case let (.servicesDiscoveryFailed(l, _), .servicesDiscoveryFailed(r, _)): return l == r
     case let (.includedServicesDiscoveryFailed(l, _), .includedServicesDiscoveryFailed(r, _)): return l == r
     // Peripherals
-    case let (.peripheralIsConnectingOrAlreadyConnected(l), .peripheralIsConnectingOrAlreadyConnected(r)): return l == r
+    case let (.peripheralIsAlreadyObservingConnection(l), .peripheralIsAlreadyObservingConnection(r)): return l == r
     case let (.peripheralConnectionFailed(l, _), .peripheralConnectionFailed(r, _)): return l == r
     case let (.peripheralDisconnected(l, _), .peripheralDisconnected(r, _)): return l == r
     case let (.peripheralRSSIReadFailed(l, _), .peripheralRSSIReadFailed(r, _)): return l == r

--- a/Tests/Autogenerated/_Connector.generated.swift
+++ b/Tests/Autogenerated/_Connector.generated.swift
@@ -71,7 +71,7 @@ class _Connector {
             )
 
             guard connectingStarted else {
-                observer.onError(_BluetoothError.peripheralIsConnectingOrAlreadyConnected(peripheral))
+                observer.onError(_BluetoothError.peripheralIsAlreadyObservingConnection(peripheral))
                 return Disposables.create()
             }
 

--- a/Tests/ConnectorTest.swift
+++ b/Tests/ConnectorTest.swift
@@ -37,7 +37,7 @@ class ConnectorTest: XCTestCase {
         testScheduler.advanceTo(subscribeTime)
         
         XCTAssertEqual(obs.events.count, 1, "should receive error event")
-        XCTAssertError(obs.events[0].value, _BluetoothError.peripheralIsConnectingOrAlreadyConnected(peripheral), "should receive correct error event")
+        XCTAssertError(obs.events[0].value, _BluetoothError.peripheralIsAlreadyObservingConnection(peripheral), "should receive correct error event")
     }
     
     func testDisconnectingPeripheral() {

--- a/scripts/all-tests.sh
+++ b/scripts/all-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$1" == "iOS" ]; then
-	set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit iOS" -destination "platform=iOS Simulator,OS=11.0,name=iPhone X" ONLY_ACTIVE_ARCH=NO | xcpretty
+	set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit iOS" -destination "platform=iOS Simulator,OS=11.3,name=iPhone 8" ONLY_ACTIVE_ARCH=NO | xcpretty
 elif [ "$1" == "macOS" ]; then
 	set -o pipefail && xcodebuild test -verbose -scheme "RxBluetoothKit macOS" ONLY_ACTIVE_ARCH=NO | xcpretty
 elif [ "$1" == "tvOS" ]; then


### PR DESCRIPTION
- changed Error.peripheralIsConnectingOrAlreadyConnected to  Error.pe…ripheralIsAlreadyObservingConnection so it better describes what happened
- updated sourcery (newest swift)
- added IDEWorskapceChecks.plist that is generated on xCode 9.3

FIXED ISSUES: #245 