### PR TITLE
Added deprecated annotation

### DIFF
--- a/Source/BluetoothError.swift
+++ b/Source/BluetoothError.swift
@@ -17,6 +17,8 @@ public enum BluetoothError: Error {
     case bluetoothResetting
     // Peripheral
     case peripheralIsAlreadyObservingConnection(Peripheral)
+    @available(*, deprecated: 5.0.2, renamed: "BluetoothError.peripheralIsAlreadyObservingConnection")
+    case peripheralIsConnectingOrAlreadyConnected(Peripheral)
     case peripheralConnectionFailed(Peripheral, Error?)
     case peripheralDisconnected(Peripheral, Error?)
     case peripheralRSSIReadFailed(Peripheral, Error?)
@@ -63,7 +65,7 @@ extension BluetoothError: CustomStringConvertible {
         case .bluetoothResetting:
             return "Bluetooth is resetting"
         // Peripheral
-        case .peripheralIsAlreadyObservingConnection:
+        case .peripheralIsAlreadyObservingConnection, .peripheralIsConnectingOrAlreadyConnected:
             return """
             Peripheral connection is already being observed.
             You cannot try to establishConnection to peripheral when you have ongoing
@@ -141,6 +143,9 @@ public func == (lhs: BluetoothError, rhs: BluetoothError) -> Bool {
     case let (.includedServicesDiscoveryFailed(l, _), .includedServicesDiscoveryFailed(r, _)): return l == r
     // Peripherals
     case let (.peripheralIsAlreadyObservingConnection(l), .peripheralIsAlreadyObservingConnection(r)): return l == r
+    case let (.peripheralIsConnectingOrAlreadyConnected(l), .peripheralIsConnectingOrAlreadyConnected(r)): return l == r
+    case let (.peripheralIsAlreadyObservingConnection(l), .peripheralIsConnectingOrAlreadyConnected(r)): return l == r
+    case let (.peripheralIsConnectingOrAlreadyConnected(l), .peripheralIsAlreadyObservingConnection(r)): return l == r
     case let (.peripheralConnectionFailed(l, _), .peripheralConnectionFailed(r, _)): return l == r
     case let (.peripheralDisconnected(l, _), .peripheralDisconnected(r, _)): return l == r
     case let (.peripheralRSSIReadFailed(l, _), .peripheralRSSIReadFailed(r, _)): return l == r

--- a/Tests/Autogenerated/_BluetoothError.generated.swift
+++ b/Tests/Autogenerated/_BluetoothError.generated.swift
@@ -18,6 +18,8 @@ enum _BluetoothError: Error {
     case bluetoothResetting
     // _Peripheral
     case peripheralIsAlreadyObservingConnection(_Peripheral)
+    @available(*, deprecated: 5.0.2, renamed: "_BluetoothError.peripheralIsAlreadyObservingConnection")
+    case peripheralIsConnectingOrAlreadyConnected(_Peripheral)
     case peripheralConnectionFailed(_Peripheral, Error?)
     case peripheralDisconnected(_Peripheral, Error?)
     case peripheralRSSIReadFailed(_Peripheral, Error?)
@@ -64,7 +66,7 @@ extension _BluetoothError: CustomStringConvertible {
         case .bluetoothResetting:
             return "Bluetooth is resetting"
         // _Peripheral
-        case .peripheralIsAlreadyObservingConnection:
+        case .peripheralIsAlreadyObservingConnection, .peripheralIsConnectingOrAlreadyConnected:
             return """
             _Peripheral connection is already being observed.
             You cannot try to establishConnection to peripheral when you have ongoing
@@ -142,6 +144,9 @@ func == (lhs: _BluetoothError, rhs: _BluetoothError) -> Bool {
     case let (.includedServicesDiscoveryFailed(l, _), .includedServicesDiscoveryFailed(r, _)): return l == r
     // Peripherals
     case let (.peripheralIsAlreadyObservingConnection(l), .peripheralIsAlreadyObservingConnection(r)): return l == r
+    case let (.peripheralIsConnectingOrAlreadyConnected(l), .peripheralIsConnectingOrAlreadyConnected(r)): return l == r
+    case let (.peripheralIsAlreadyObservingConnection(l), .peripheralIsConnectingOrAlreadyConnected(r)): return l == r
+    case let (.peripheralIsConnectingOrAlreadyConnected(l), .peripheralIsAlreadyObservingConnection(r)): return l == r
     case let (.peripheralConnectionFailed(l, _), .peripheralConnectionFailed(r, _)): return l == r
     case let (.peripheralDisconnected(l, _), .peripheralDisconnected(r, _)): return l == r
     case let (.peripheralRSSIReadFailed(l, _), .peripheralRSSIReadFailed(r, _)): return l == r

--- a/Tests/ConnectorTest.swift
+++ b/Tests/ConnectorTest.swift
@@ -38,6 +38,7 @@ class ConnectorTest: XCTestCase {
         
         XCTAssertEqual(obs.events.count, 1, "should receive error event")
         XCTAssertError(obs.events[0].value, _BluetoothError.peripheralIsAlreadyObservingConnection(peripheral), "should receive correct error event")
+        XCTAssertError(obs.events[0].value, _BluetoothError.peripheralIsConnectingOrAlreadyConnected(peripheral), "should receive correct error event")
     }
     
     func testDisconnectingPeripheral() {


### PR DESCRIPTION
Added depreacted annotation to `BluetoothError.peripheralIsConnectingOrAlreadyConnected` instead of removing it.

Removing it would require us to update version number to 6.x, because of api changes. We don't want to do this, so I've added `deprecated` annotation.