### PR TITLE
remove `self` = self

### DIFF
--- a/ExampleApp/ExampleApp/Common/Services/RxBluetoothKitService.swift
+++ b/ExampleApp/ExampleApp/Common/Services/RxBluetoothKitService.swift
@@ -94,10 +94,10 @@ final class RxBluetoothKitService {
         .subscribeOn(MainScheduler.instance)
         .timeout(4.0, scheduler: scheduler)
         .flatMap { [weak self] _ -> Observable<ScannedPeripheral> in
-            guard let `self` = self else {
+            guard let strongSelf = self else {
                 return Observable.empty()
             }
-            return self.centralManager.scanForPeripherals(withServices: nil)
+            return strongSelf.centralManager.scanForPeripherals(withServices: nil)
         }.subscribe(onNext: { [weak self] scannedPeripheral in
                     self?.scanningSubject.onNext(Result.success(scannedPeripheral))
                 }, onError: { [weak self] error in


### PR DESCRIPTION
`self`= self is a known compiler bug and it seems like you have fixed it or avoided it in the rest of the project. Found this in the Example App when using it to learn about RxBluetoothKit