### PR TITLE
Add Swift Version to Podspec

### DIFF
--- a/RxBluetoothKit.podspec
+++ b/RxBluetoothKit.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '4.0'
   s.tvos.deployment_target = '11.0'
+	s.swift_version = '4.2'
 
   s.requires_arc = true
 


### PR DESCRIPTION
Added the swift version parameter to the podspec.   This will keep the pod from breaking when new versions of Swift are released.

Not sure if this is something you want in the codebase, but it avoids having to add code like the following to everyone's Podfile.

```
post_install do |installer|
    installer.pods_project.targets.each do |target|
        if target.name == '<insert target name of your pod here>'
            target.build_configurations.each do |config|
                config.build_settings['SWIFT_VERSION'] = '3.0'
            end
        end
    end
end
```