### PR TITLE
Check if gnu-sed is install on travis and install if required.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 before_install:
 - brew update
 - brew outdated carthage || brew upgrade carthage
+- brew list gnu-sed || brew install gnu-sed
 before_script:
 - travis_retry carthage bootstrap --platform "${TARGET}"
 script:


### PR DESCRIPTION
Now `gsed` is not installed on travis image and this prevents running `generate-testable.sh` script on the CI. This caused that changes from PR could be not tested unless someone pushed new autogenerated files. After this changes author should get information from the CI if tests fail after his changes.