### PR TITLE
Fixed an issue where the SPM package doesn't compile with Xcode 11.4

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "002d325b0bdee94e7882e1114af5ff4fe1e96afa",
+          "version": "5.1.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
                 path: ".",
                 exclude: [
                     "Example",
-                    "Tests"
+                    "Tests",
+                    "Source/Info.plist"
                 ],
                 sources: [
                     "Source"


### PR DESCRIPTION
After updating to Xcode 11.4, my project is showing the following issue with RxBluetoothKit:

```
xcodebuild: error: Could not resolve package dependencies:
   target at '/Users/xcode/Library/Developer/Xcode/DerivedData/project-btxgpemzyyretjcousmtwoebmywz/SourcePackages/checkouts/RxBluetoothKit' contains mixed language source files; feature not supported
```

I've been able to track down the error to the [Info.plist](https://github.com/Polidea/RxBluetoothKit/blob/master/Source/Info.plist) file in the Sources folder.

For whatever reason, Xcode 11.4 now doesn't like that there's a file that's now a `.swift` one. (Xcode 11.3.1 still works fine)

I've included that file in the excluded section in the package description, which solves the issue.