### PR TITLE
Fixed an issue where the SPM package doesn't compile with Xcode 11.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
                 exclude: [
                     "Example",
                     "Tests",
-                    "Source/Info.plist"
+                    "Source/Info.plist",
+                    "Source/RxBluetoothKit.h"
                 ],
                 sources: [
                     "Source"

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
                 path: ".",
                 exclude: [
                     "Example",
-                    "Tests"
+                    "Tests",
+                    "Source/Info.plist"
                 ],
                 sources: [
                     "Source"


### PR DESCRIPTION
After updating to Xcode 11.4, my project is showing the following issue with RxBluetoothKit:

```
xcodebuild: error: Could not resolve package dependencies:
   target at '/Users/xcode/Library/Developer/Xcode/DerivedData/project-btxgpemzyyretjcousmtwoebmywz/SourcePackages/checkouts/RxBluetoothKit' contains mixed language source files; feature not supported
```

I've been able to track down the error to the [Info.plist](https://github.com/Polidea/RxBluetoothKit/blob/master/Source/Info.plist) file in the Sources folder.

For whatever reason, Xcode 11.4 now doesn't like that there's a file that's not a `.swift` one. (Xcode 11.3.1 still works fine)

I've included that file in the excluded section in the package description, which solves the issue.