### PR TITLE
Added support for observing ancsAuthorized property on peripheral.

### DIFF
--- a/Source/CBCentralManagerDelegateWrapper.swift
+++ b/Source/CBCentralManagerDelegateWrapper.swift
@@ -10,6 +10,7 @@ class CBCentralManagerDelegateWrapper: NSObject, CBCentralManagerDelegate {
     let didConnectPeripheral = PublishSubject<CBPeripheral>()
     let didFailToConnectPeripheral = PublishSubject<(CBPeripheral, Error?)>()
     let didDisconnectPeripheral = PublishSubject<(CBPeripheral, Error?)>()
+    let didUpdateANCSAuthorizationForPeripheral = PublishSubject<(CBPeripheral)>()
 
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         guard let bleState = BluetoothState(rawValue: central.state.rawValue) else { return }
@@ -59,4 +60,16 @@ class CBCentralManagerDelegateWrapper: NSObject, CBCentralManagerDelegate {
             """)
         didDisconnectPeripheral.onNext((peripheral, error))
     }
+
+    #if !os(macOS)
+    @available(iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func centralManager(_ central: CBCentralManager,
+                        didUpdateANCSAuthorizationFor peripheral: CBPeripheral) {
+        RxBluetoothKitLog.d("""
+            \(central.logDescription) didUpdateANCSAuthorizationFor
+            (peripheral: \(peripheral.logDescription)
+            """)
+        didUpdateANCSAuthorizationForPeripheral.onNext(peripheral)
+    }
+    #endif
 }

--- a/Source/CentralManager.swift
+++ b/Source/CentralManager.swift
@@ -285,7 +285,6 @@ public class CentralManager: ManagerType {
                 }
     }
 
-
     // MARK: ANCS
 
     /// Emits boolean values according to ancsAuthorized property on a CBPeripheral.
@@ -298,7 +297,10 @@ public class CentralManager: ManagerType {
         let observable = delegateWrapper.didUpdateANCSAuthorizationForPeripheral
             .asObservable()
             .filter { $0 == peripheral.peripheral }
-            .map { $0.ancsAuthorized }
+            // ancsAuthorized is a Bool by default, but the testing framework
+            // will use Bool! instead. In order to support that we are converting
+            // to optional and unwrapping the value.
+            .map { ($0.ancsAuthorized as Bool?)! }
 
         return ensure(.poweredOn, observable: observable)
     }

--- a/Source/CentralManager.swift
+++ b/Source/CentralManager.swift
@@ -285,6 +285,25 @@ public class CentralManager: ManagerType {
                 }
     }
 
+
+    // MARK: ANCS
+
+    /// Emits boolean values according to ancsAuthorized property on a CBPeripheral.
+    ///
+    /// - parameter peripheral: `Peripheral` which is observed for ancsAuthorized chances.
+    /// - returns: Observable which emits next events when `ancsAuthorized` property changes on a peripheral.
+    #if !os(macOS)
+    @available(iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    public func observeANCSAuthorized(for peripheral: Peripheral) -> Observable<Bool> {
+        let observable = delegateWrapper.didUpdateANCSAuthorizationForPeripheral
+            .asObservable()
+            .filter { $0 == peripheral.peripheral }
+            .map { $0.ancsAuthorized }
+
+        return ensure(.poweredOn, observable: observable)
+    }
+    #endif
+
     // MARK: Internal functions
 
     /// Ensure that specified `peripheral` is connected during subscription.

--- a/Tests/Autogenerated/Mock.generated.swift
+++ b/Tests/Autogenerated/Mock.generated.swift
@@ -555,6 +555,7 @@ class CBCentralManagerDelegateWrapperMock: NSObject , CBCentralManagerDelegate {
     var didConnectPeripheral = PublishSubject<CBPeripheralMock>()
     var didFailToConnectPeripheral = PublishSubject<(CBPeripheralMock, Error?)>()
     var didDisconnectPeripheral = PublishSubject<(CBPeripheralMock, Error?)>()
+    var didUpdateANCSAuthorizationForPeripheral = PublishSubject<(CBPeripheral)>()
 
     override init() {
     }
@@ -576,6 +577,12 @@ class CBCentralManagerDelegateWrapperMock: NSObject , CBCentralManagerDelegate {
 
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
     }
+
+    #if !os(macOS)
+    @available(iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func centralManager(_ central: CBCentralManager, didUpdateANCSAuthorizationFor peripheral: CBPeripheral) {
+    }
+    #endif
 
 }
 class CBPeripheralManagerDelegateWrapperMock: NSObject , CBPeripheralManagerDelegate {

--- a/Tests/Autogenerated/Mock.generated.swift
+++ b/Tests/Autogenerated/Mock.generated.swift
@@ -168,6 +168,7 @@ class CBPeripheralMock: CBPeerMock {
     var state: CBPeripheralState!
     var services: [CBServiceMock]?
     var canSendWriteWithoutResponse: Bool!
+    var ancsAuthorized: Bool!
     var logDescription: String!
     var uuidIdentifier: UUID!
 
@@ -555,7 +556,7 @@ class CBCentralManagerDelegateWrapperMock: NSObject , CBCentralManagerDelegate {
     var didConnectPeripheral = PublishSubject<CBPeripheralMock>()
     var didFailToConnectPeripheral = PublishSubject<(CBPeripheralMock, Error?)>()
     var didDisconnectPeripheral = PublishSubject<(CBPeripheralMock, Error?)>()
-    var didUpdateANCSAuthorizationForPeripheral = PublishSubject<(CBPeripheral)>()
+    var didUpdateANCSAuthorizationForPeripheral = PublishSubject<(CBPeripheralMock)>()
 
     override init() {
     }
@@ -578,11 +579,8 @@ class CBCentralManagerDelegateWrapperMock: NSObject , CBCentralManagerDelegate {
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
     }
 
-    #if !os(macOS)
-    @available(iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func centralManager(_ central: CBCentralManager, didUpdateANCSAuthorizationFor peripheral: CBPeripheral) {
     }
-    #endif
 
 }
 class CBPeripheralManagerDelegateWrapperMock: NSObject , CBPeripheralManagerDelegate {

--- a/Tests/Autogenerated/Mock.generated.swift
+++ b/Tests/Autogenerated/Mock.generated.swift
@@ -579,9 +579,10 @@ class CBCentralManagerDelegateWrapperMock: NSObject , CBCentralManagerDelegate {
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
     }
 
+    #if !os(macOS)
     func centralManager(_ central: CBCentralManager, didUpdateANCSAuthorizationFor peripheral: CBPeripheral) {
     }
-
+    #endif
 }
 class CBPeripheralManagerDelegateWrapperMock: NSObject , CBPeripheralManagerDelegate {
     var didUpdateState = PublishSubject<BluetoothState>()

--- a/Tests/Autogenerated/Mock.generated.swift
+++ b/Tests/Autogenerated/Mock.generated.swift
@@ -596,6 +596,11 @@ class CBCentralManagerDelegateWrapperMock: NSObject , CBCentralManagerDelegate {
 
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
     }
+
+    #if !os(macOS)
+    func centralManager(_ central: CBCentralManager, didUpdateANCSAuthorizationFor peripheral: CBPeripheral) {
+    }
+    #endif
 }
 class CBPeripheralManagerDelegateWrapperMock: NSObject , CBPeripheralManagerDelegate {
     var didUpdateState = PublishSubject<BluetoothState>()

--- a/Tests/Autogenerated/_CentralManager.generated.swift
+++ b/Tests/Autogenerated/_CentralManager.generated.swift
@@ -286,7 +286,6 @@ class _CentralManager: _ManagerType {
                 }
     }
 
-
     // MARK: ANCS
 
     /// Emits boolean values according to ancsAuthorized property on a CBPeripheralMock.
@@ -299,7 +298,10 @@ class _CentralManager: _ManagerType {
         let observable = delegateWrapper.didUpdateANCSAuthorizationForPeripheral
             .asObservable()
             .filter { $0 == peripheral.peripheral }
-            .map { $0.ancsAuthorized }
+            // ancsAuthorized is a Bool by default, but the testing framework
+            // will use Bool! instead. In order to support that we are converting
+            // to optional and unwrapping the value.
+            .map { ($0.ancsAuthorized as Bool?)! }
 
         return ensure(.poweredOn, observable: observable)
     }

--- a/Tests/Autogenerated/_CentralManager.generated.swift
+++ b/Tests/Autogenerated/_CentralManager.generated.swift
@@ -286,6 +286,25 @@ class _CentralManager: _ManagerType {
                 }
     }
 
+
+    // MARK: ANCS
+
+    /// Emits boolean values according to ancsAuthorized property on a CBPeripheralMock.
+    ///
+    /// - parameter peripheral: `_Peripheral` which is observed for ancsAuthorized chances.
+    /// - returns: Observable which emits next events when `ancsAuthorized` property changes on a peripheral.
+    #if !os(macOS)
+    @available(iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func observeANCSAuthorized(for peripheral: _Peripheral) -> Observable<Bool> {
+        let observable = delegateWrapper.didUpdateANCSAuthorizationForPeripheral
+            .asObservable()
+            .filter { $0 == peripheral.peripheral }
+            .map { $0.ancsAuthorized }
+
+        return ensure(.poweredOn, observable: observable)
+    }
+    #endif
+
     // MARK: Internal functions
 
     /// Ensure that specified `peripheral` is connected during subscription.


### PR DESCRIPTION
Added support for `ancsAuthorized` property that was introduced in iOS 13: https://developer.apple.com/documentation/corebluetooth/cbperipheral/3180040-ancsauthorized