### PR TITLE
Added initial state improvement & a minor fix for BluetoothState methods.

### DIFF
--- a/Source/CentralManager.swift
+++ b/Source/CentralManager.swift
@@ -8,10 +8,11 @@ public typealias DisconnectionReason = Error
 /// CentralManager is a class implementing ReactiveX API which wraps all Core Bluetooth Manager's functions allowing to
 /// discover, connect to remote peripheral devices and more.
 /// You can start using this class by discovering available services of nearby peripherals. Before calling any
-/// public `CentralManager`'s functions you should make sure that Bluetooth is turned on and powered on. It can be done
-/// by calling and observing returned value of `observeState()` and then chaining it with `scanForPeripherals(_:options:)`:
+/// public `CentralManager`'s functions you should make sure that Bluetooth is turned on and powered on.
+/// It can be done by calling and observing returned value of `observeStateWithInitialValue()` and then
+/// chaining it with `scanForPeripherals(_:options:)`:
 /// ```
-/// let disposable = centralManager.observeState()
+/// let disposable = centralManager.observeStateWithInitialValue()
 ///     .filter { $0 == .poweredOn }
 ///     .take(1)
 ///     .flatMap { centralManager.scanForPeripherals(nil) }
@@ -95,6 +96,10 @@ public class CentralManager: ManagerType {
     }
 
     public func observeState() -> Observable<BluetoothState> {
+        return self.delegateWrapper.didUpdateState.asObservable()
+    }
+
+    public func observeStateWithInitialValue() -> Observable<BluetoothState> {
         return Observable.deferred { [weak self] in
             guard let self = self else {
                 RxBluetoothKitLog.w("observeState - CentralManager deallocated")

--- a/Source/ManagerType.swift
+++ b/Source/ManagerType.swift
@@ -12,10 +12,16 @@ public protocol ManagerType: class {
     var state: BluetoothState { get }
 
     /// Continuous state of `CBManager` instance described by `BluetoothState` which is equivalent to  [CBManagerState](https://developer.apple.com/documentation/corebluetooth/cbmanagerstate).
-    /// - returns: Observable that emits `next` event starting with current state and whenever state changes.
+    /// - returns: Observable that emits `next` event whenever state changes.
     ///
     /// It's **infinite** stream, so `.complete` is never called.
     func observeState() -> Observable<BluetoothState>
+
+    /// Continuous state of `CBManager` instance described by `BluetoothState` which is equivalent to  [CBManagerState](https://developer.apple.com/documentation/corebluetooth/cbmanagerstate).
+    /// - returns: Observable that emits `next` event starting with current state and whenever state changes.
+    ///
+    /// It's **infinite** stream, so `.complete` is never called.
+    func observeStateWithInitialValue() -> Observable<BluetoothState>
 }
 
 public extension ManagerType {
@@ -27,7 +33,7 @@ public extension ManagerType {
     func ensure<T>(_ state: BluetoothState, observable: Observable<T>) -> Observable<T> {
         return .deferred { [weak self] in
             guard let strongSelf = self else { throw BluetoothError.destroyed }
-            let statesObservable = strongSelf.observeState()
+            let statesObservable = strongSelf.observeStateWithInitialValue()
                 .filter { $0 != state && BluetoothError(state: $0) != nil }
                 .map { state -> T in throw BluetoothError(state: state)! }
             return .absorb(statesObservable, observable)

--- a/Source/ManagerType.swift
+++ b/Source/ManagerType.swift
@@ -12,7 +12,7 @@ public protocol ManagerType: class {
     var state: BluetoothState { get }
 
     /// Continuous state of `CBManager` instance described by `BluetoothState` which is equivalent to  [CBManagerState](https://developer.apple.com/documentation/corebluetooth/cbmanagerstate).
-    /// - returns: Observable that emits `next` event whenever state changes.
+    /// - returns: Observable that emits `next` event starting with current state and whenever state changes.
     ///
     /// It's **infinite** stream, so `.complete` is never called.
     func observeState() -> Observable<BluetoothState>
@@ -28,7 +28,6 @@ public extension ManagerType {
         return .deferred { [weak self] in
             guard let strongSelf = self else { throw BluetoothError.destroyed }
             let statesObservable = strongSelf.observeState()
-                .startWith(strongSelf.state)
                 .filter { $0 != state && BluetoothError(state: $0) != nil }
                 .map { state -> T in throw BluetoothError(state: state)! }
             return .absorb(statesObservable, observable)

--- a/Source/PeripheralManager.swift
+++ b/Source/PeripheralManager.swift
@@ -8,8 +8,7 @@ import RxSwift
 /// Before calling any public `PeripheralManager`'s functions you should make sure that Bluetooth is turned on and powered on. It can be done
 /// by `observeState()`, observing it's value and then chaining it with `add(_:)` and `startAdvertising(_:)`:
 /// ```
-/// let disposable = centralManager.observeState
-///     .startWith(centralManager.state)
+/// let disposable = centralManager.observeState()
 ///     .filter { $0 == .poweredOn }
 ///     .take(1)
 ///     .flatMap { centralManager.add(myService) }
@@ -69,11 +68,19 @@ public class PeripheralManager: ManagerType {
     // MARK: State
 
     public var state: BluetoothState {
-        return BluetoothState(rawValue: manager.state.rawValue) ?? .unsupported
+        return BluetoothState(rawValue: manager.state.rawValue) ?? .unknown
     }
 
     public func observeState() -> Observable<BluetoothState> {
-        return self.delegateWrapper.didUpdateState.asObservable()
+        return Observable.deferred { [weak self] in
+            guard let self = self else {
+                RxBluetoothKitLog.w("observeState - PeripheralManager deallocated")
+                return .never()
+            }
+
+            return self.delegateWrapper.didUpdateState.asObservable()
+                .startWith(self.state)
+        }
     }
 
     // MARK: Advertising

--- a/Source/PeripheralManager.swift
+++ b/Source/PeripheralManager.swift
@@ -6,9 +6,9 @@ import RxSwift
 /// advertise, to publish L2CAP channels and more.
 /// You can start using this class by adding services and starting advertising.
 /// Before calling any public `PeripheralManager`'s functions you should make sure that Bluetooth is turned on and powered on. It can be done
-/// by `observeState()`, observing it's value and then chaining it with `add(_:)` and `startAdvertising(_:)`:
+/// by `observeStateWithInitialValue()`, observing it's value and then chaining it with `add(_:)` and `startAdvertising(_:)`:
 /// ```
-/// let disposable = centralManager.observeState()
+/// let disposable = centralManager.observeStateWithInitialValue()
 ///     .filter { $0 == .poweredOn }
 ///     .take(1)
 ///     .flatMap { centralManager.add(myService) }
@@ -72,6 +72,10 @@ public class PeripheralManager: ManagerType {
     }
 
     public func observeState() -> Observable<BluetoothState> {
+        return self.delegateWrapper.didUpdateState.asObservable()
+    }
+
+    public func observeStateWithInitialValue() -> Observable<BluetoothState> {
         return Observable.deferred { [weak self] in
             guard let self = self else {
                 RxBluetoothKitLog.w("observeState - PeripheralManager deallocated")

--- a/Tests/Autogenerated/_CentralManager.generated.swift
+++ b/Tests/Autogenerated/_CentralManager.generated.swift
@@ -9,10 +9,11 @@ typealias DisconnectionReason = Error
 /// _CentralManager is a class implementing ReactiveX API which wraps all Core Bluetooth Manager's functions allowing to
 /// discover, connect to remote peripheral devices and more.
 /// You can start using this class by discovering available services of nearby peripherals. Before calling any
-/// public `_CentralManager`'s functions you should make sure that Bluetooth is turned on and powered on. It can be done
-/// by calling and observing returned value of `observeState()` and then chaining it with `scanForPeripherals(_:options:)`:
+/// public `_CentralManager`'s functions you should make sure that Bluetooth is turned on and powered on.
+/// It can be done by calling and observing returned value of `observeStateWithInitialValue()` and then
+/// chaining it with `scanForPeripherals(_:options:)`:
 /// ```
-/// let disposable = centralManager.observeState()
+/// let disposable = centralManager.observeStateWithInitialValue()
 ///     .filter { $0 == .poweredOn }
 ///     .take(1)
 ///     .flatMap { centralManager.scanForPeripherals(nil) }
@@ -96,6 +97,10 @@ class _CentralManager: _ManagerType {
     }
 
     func observeState() -> Observable<BluetoothState> {
+        return self.delegateWrapper.didUpdateState.asObservable()
+    }
+
+    func observeStateWithInitialValue() -> Observable<BluetoothState> {
         return Observable.deferred { [weak self] in
             guard let self = self else {
                 RxBluetoothKitLog.w("observeState - _CentralManager deallocated")

--- a/Tests/Autogenerated/_ManagerType.generated.swift
+++ b/Tests/Autogenerated/_ManagerType.generated.swift
@@ -13,10 +13,16 @@ protocol _ManagerType: class {
     var state: BluetoothState { get }
 
     /// Continuous state of `CBManagerMock` instance described by `BluetoothState` which is equivalent to  [CBManagerState](https://developer.apple.com/documentation/corebluetooth/cbmanagerstate).
-    /// - returns: Observable that emits `next` event starting with current state and whenever state changes.
+    /// - returns: Observable that emits `next` event whenever state changes.
     ///
     /// It's **infinite** stream, so `.complete` is never called.
     func observeState() -> Observable<BluetoothState>
+
+    /// Continuous state of `CBManagerMock` instance described by `BluetoothState` which is equivalent to  [CBManagerState](https://developer.apple.com/documentation/corebluetooth/cbmanagerstate).
+    /// - returns: Observable that emits `next` event starting with current state and whenever state changes.
+    ///
+    /// It's **infinite** stream, so `.complete` is never called.
+    func observeStateWithInitialValue() -> Observable<BluetoothState>
 }
 
 extension _ManagerType {
@@ -28,7 +34,7 @@ extension _ManagerType {
     func ensure<T>(_ state: BluetoothState, observable: Observable<T>) -> Observable<T> {
         return .deferred { [weak self] in
             guard let strongSelf = self else { throw _BluetoothError.destroyed }
-            let statesObservable = strongSelf.observeState()
+            let statesObservable = strongSelf.observeStateWithInitialValue()
                 .filter { $0 != state && _BluetoothError(state: $0) != nil }
                 .map { state -> T in throw _BluetoothError(state: state)! }
             return .absorb(statesObservable, observable)

--- a/Tests/Autogenerated/_ManagerType.generated.swift
+++ b/Tests/Autogenerated/_ManagerType.generated.swift
@@ -13,7 +13,7 @@ protocol _ManagerType: class {
     var state: BluetoothState { get }
 
     /// Continuous state of `CBManagerMock` instance described by `BluetoothState` which is equivalent to  [CBManagerState](https://developer.apple.com/documentation/corebluetooth/cbmanagerstate).
-    /// - returns: Observable that emits `next` event whenever state changes.
+    /// - returns: Observable that emits `next` event starting with current state and whenever state changes.
     ///
     /// It's **infinite** stream, so `.complete` is never called.
     func observeState() -> Observable<BluetoothState>
@@ -29,7 +29,6 @@ extension _ManagerType {
         return .deferred { [weak self] in
             guard let strongSelf = self else { throw _BluetoothError.destroyed }
             let statesObservable = strongSelf.observeState()
-                .startWith(strongSelf.state)
                 .filter { $0 != state && _BluetoothError(state: $0) != nil }
                 .map { state -> T in throw _BluetoothError(state: state)! }
             return .absorb(statesObservable, observable)

--- a/Tests/Autogenerated/_PeripheralManager.generated.swift
+++ b/Tests/Autogenerated/_PeripheralManager.generated.swift
@@ -7,9 +7,9 @@ import RxSwift
 /// advertise, to publish L2CAP channels and more.
 /// You can start using this class by adding services and starting advertising.
 /// Before calling any public `_PeripheralManager`'s functions you should make sure that Bluetooth is turned on and powered on. It can be done
-/// by `observeState()`, observing it's value and then chaining it with `add(_:)` and `startAdvertising(_:)`:
+/// by `observeStateWithInitialValue()`, observing it's value and then chaining it with `add(_:)` and `startAdvertising(_:)`:
 /// ```
-/// let disposable = centralManager.observeState()
+/// let disposable = centralManager.observeStateWithInitialValue()
 ///     .filter { $0 == .poweredOn }
 ///     .take(1)
 ///     .flatMap { centralManager.add(myService) }
@@ -73,6 +73,10 @@ class _PeripheralManager: _ManagerType {
     }
 
     func observeState() -> Observable<BluetoothState> {
+        return self.delegateWrapper.didUpdateState.asObservable()
+    }
+
+    func observeStateWithInitialValue() -> Observable<BluetoothState> {
         return Observable.deferred { [weak self] in
             guard let self = self else {
                 RxBluetoothKitLog.w("observeState - _PeripheralManager deallocated")


### PR DESCRIPTION
This PR will add 1 fix and 1 improvement for BluetoothState methods:
* report `unknown` if CBCentralManager doesn't have a state yet. This feels the right state to report in this case, since we can't say for sure that Bluetooth is unsupported. 
* added a new method for initial state on `observeState()`. This will also be emitted upon subscription, using deferred syntax. The main reason behind this is that perhaps all use-cases when observing the BluetoothState you will also want to check the initial state. All the examples in the code also use this and any app that wants to present BT state will probably also need an initial value. Moreover, the examples in the code currently use `startWith`, but they don't take into consideration when the subscription happened. If the subscription happens at a later time, that startWith might have a different value, and it becomes useless. In order to fix this, the user will always need to use the `deferred` syntax to be sure that he actually has the latest bluetooth state. This feels like an improvement that we can do for the users.