### PR TITLE
Correct Min MacOS version for CoreBluetooth Framework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "RxBluetoothKit",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v11), .watchOS(.v4)
+        .macOS(.v10_13), .iOS(.v8), .tvOS(.v11), .watchOS(.v4)
     ],
     products: [
         .library(name: "RxBluetoothKit", targets: ["RxBluetoothKit"])


### PR DESCRIPTION
'CBCentralManagerRestoredStatePeripheralsKey' is only available in macOS 10.13 or newer

CBCentralManagerRestoredStatePeripheralsKey is used in CentralManagerRestoredState.swift. Currently, compiling for macOS causes errors because the min macOS version is set to 10.10 and CBCentralManagerRestoredStatePeripheralsKey is not available.