### PR TITLE
Fix builds

### DIFF
--- a/Source/CentralManagerRestoredState.swift
+++ b/Source/CentralManagerRestoredState.swift
@@ -60,7 +60,7 @@ public struct CentralManagerRestoredState: CentralManagerRestoredStateType {
         let cbServices = arrayOfAnyObjects.flatMap { $0 as? CBService }
         #endif
 
-        return cbServices.map { Service(peripheral: centralManager.retrievePeripheral(for: $0.peripheral),
+        return cbServices.map { Service(peripheral: centralManager.retrievePeripheral(for: $0.peripheral!), // TODO: unsafe unwrap
                                         service: $0) }
     }
 }

--- a/Source/Characteristic.swift
+++ b/Source/Characteristic.swift
@@ -41,7 +41,7 @@ public class Characteristic {
     }
 
     convenience init(characteristic: CBCharacteristic, peripheral: Peripheral) {
-        let service = Service(peripheral: peripheral, service: characteristic.service)
+        let service = Service(peripheral: peripheral, service: characteristic.service!) // TODO: unsafe unwrap
         self.init(characteristic: characteristic, service: service)
     }
 

--- a/Source/Descriptor.swift
+++ b/Source/Descriptor.swift
@@ -29,8 +29,8 @@ public class Descriptor {
     }
 
     convenience init(descriptor: CBDescriptor, peripheral: Peripheral) {
-        let service = Service(peripheral: peripheral, service: descriptor.characteristic.service)
-        let characteristic = Characteristic(characteristic: descriptor.characteristic, service: service)
+        let service = Service(peripheral: peripheral, service: descriptor.characteristic!.service!) // TODO: unsafe unwrap
+        let characteristic = Characteristic(characteristic: descriptor.characteristic!, service: service) // TODO: unsafe unwrap
         self.init(descriptor: descriptor, characteristic: characteristic)
     }
 


### PR DESCRIPTION
- Unsafely unwrap optionals to get builds to run again. This is no better than the original code, but should be returned to for safety.